### PR TITLE
fix: correct README examples and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ require("xmap").setup({
   -- Rendering options
   render = {
     relative_prefix = {
-      number_width = 3,
+      number_width = 4,
       number_separator = " ",
       separator = " ",
       direction = {
@@ -352,7 +352,6 @@ For very large files (10,000+ lines), consider:
 require("xmap").setup({
   render = {
     throttle_ms = 200,  -- Increase throttle
-    mode = "compact",   -- Use compact mode
   },
   treesitter = {
     highlight_scopes = false,  -- Disable structural highlighting

--- a/lua/xmap/init.lua
+++ b/lua/xmap/init.lua
@@ -284,6 +284,6 @@ function M.diagnose()
 end
 
 -- Get plugin version
-M.version = "0.6.0"
+M.version = "0.7.0"
 
 return M


### PR DESCRIPTION
## Fixes

Fixed three issues found in README examples:

### 1. Incorrect `number_width` default
- **Was:** `number_width = 3`
- **Now:** `number_width = 4`
- **Reason:** Matches actual default in `lua/xmap/config.lua`

### 2. Invalid `mode` option
- **Removed:** `mode = "compact"` from Performance section example
- **Reason:** This option doesn't exist in the codebase

### 3. Outdated version
- **Was:** `M.version = "0.6.0"`
- **Now:** `M.version = "0.7.0"`
- **Location:** `lua/xmap/init.lua`

## Impact

- Documentation now matches actual code behavior
- Users won't be confused by non-existent options
- Version string is correct for v0.7.0 release

## Testing

- Verified all default values match config.lua
- Confirmed `mode` option doesn't exist in codebase
- Checked version matches release tag