### PR TITLE
chore: apply refined familiar comment contract across xmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,37 @@
 .PHONY: test test-swift test-lua test-ts test-tsx test-c test-cpp test-follow dev clean install-local
 
-# AI HINTS: Test with minimal config (default: Swift)
+# PURPOSE:
+# - Manual smoke and local dev targets.
 test:
 	nvim -u test_config.lua test.swift
 
-# AI HINTS: Test with Swift file
 test-swift:
 	nvim -u test_config.lua test.swift
 
-# AI HINTS: Test with Lua file
 test-lua:
 	nvim -u test_config.lua test.lua
 
-# AI HINTS: Test with TypeScript file
 test-ts:
 	nvim -u test_config.lua test.ts
 
-# AI HINTS: Test with TSX file
 test-tsx:
 	nvim -u test_config.lua test.tsx
 
-# AI HINTS: Test with C file
 test-c:
 	nvim -u test_config.lua test.c
 
-# AI HINTS: Test with C++ file
 test-cpp:
 	nvim -u test_config.lua test.cpp
 
-# AI HINTS: Headless QA regression checks
 test-follow:
 	nvim --headless -n -i NONE -u test_config.lua -c "lua dofile('scripts/qa_follow_active_buffer.lua')"
 
-# AI HINTS: Open for development (uses your actual config)
 dev:
 	nvim -c "set rtp+=." test.swift
 
-# AI HINTS: Clean generated files
 clean:
 	rm -f profile.log
 
-# AI HINTS: Create symlink for local development with lazy.nvim
 install-local:
 	@echo "Add this to your lazy.nvim config:"
 	@echo ""
@@ -52,7 +43,6 @@ install-local:
 	@echo "  end,"
 	@echo "}"
 
-# AI HINTS: Help
 help:
 	@echo "xmap.nvim development commands:"
 	@echo ""

--- a/debug_highlights.lua
+++ b/debug_highlights.lua
@@ -1,5 +1,6 @@
--- AI HINTS: Debug script to check actual highlight values
--- AI HINTS: Run with: :luafile debug_highlights.lua
+
+-- PURPOSE:
+-- - Print resolved highlight values for manual theme debugging.
 
 print("=== Current Xmap Highlight Groups ===\n")
 
@@ -22,7 +23,6 @@ end
 
 print("\n=== Checking if split_entity is working ===")
 local nav = require("xmap.navigation")
--- AI HINTS: Test the entity format
 local test_entity = "func sendRequest"
 print("Input: '" .. test_entity .. "'")
 local keyword, name = test_entity:match("^(%S+)%s+(.+)$")

--- a/debug_positions.lua
+++ b/debug_positions.lua
@@ -1,5 +1,6 @@
--- AI HINTS: Debug minimap line highlighting positions
--- AI HINTS: Run with: :luafile debug_positions.lua
+
+-- PURPOSE:
+-- - Inspect rendered minimap text and extmarks when highlight spans look wrong.
 
 print("=== Debugging Minimap Line Positions ===\n")
 
@@ -17,8 +18,6 @@ print("First 10 minimap lines:\n")
 for i, line in ipairs(lines) do
   print(string.format("Line %d: '%s'", i, line))
   print(string.format("  Length: %d", #line))
-
-  -- AI HINTS: Try to find keywords
   local text_after_icon = line:sub(8)
   print(string.format("  After pos 8: '%s'", text_after_icon))
 

--- a/lua/xmap/config.lua
+++ b/lua/xmap/config.lua
@@ -1,155 +1,98 @@
--- AI HINTS: lua/xmap/config.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- PURPOSE: Centralize config defaults + runtime config checks for xmap.
--- OUTPUT: Stable config table via `get()`, support predicates via helper APIs.
--- DEPENDENCIES: `xmap.lang` provider registry for filetype availability checks.
--- CONSTRAINTS: Config module must not open/close windows or mutate editor layout.
--- STABILITY: Core
+
+-- PURPOSE:
+-- - Own default options and config-derived capability checks.
+-- CONSTRAINTS:
+-- - Filetype support requires both config opt-in and a loaded provider.
 
 local M = {}
 
--- PURPOSE: Built-in provider filetypes.
--- AI HINTS: Add new filetypes only with matching provider module at `lua/xmap/lang/<filetype>.lua`.
+-- PURPOSE:
+-- - Keep bundled provider filetypes in one place.
 local DEFAULT_FILETYPES = { "swift", "typescript", "typescriptreact", "lua", "markdown", "c", "cpp", "h", "hpp" }
 
 local function get_default_filetypes()
 	return vim.deepcopy(DEFAULT_FILETYPES)
 end
-
--- AI HINTS: Default configuration
 M.defaults = {
-	-- AI HINTS: Window settings
-	width = 40, -- AI HINTS: Width of the minimap window (for relative numbers + icons + text)
-	side = "right", -- AI HINTS: "right" or "left" (pinned to tabpage edge)
-	auto_open = false, -- AI HINTS: Automatically open minimap for supported filetypes
-
-	-- AI HINTS: Filetypes where minimap should be enabled
+	width = 40,
+	side = "right",
+	auto_open = false,
 	filetypes = get_default_filetypes(),
-
-	-- AI HINTS: Filetypes to exclude
 	exclude_filetypes = { "help", "terminal", "prompt", "qf", "neo-tree", "NvimTree", "lazy" },
-
-	-- AI HINTS: Keymaps (set to false to disable default mappings)
 	keymaps = {
-		toggle = "<leader>mm", -- AI HINTS: Toggle minimap
-		focus = "<leader>mf", -- AI HINTS: Focus minimap window
-		jump = "<CR>", -- AI HINTS: Jump to line (inside minimap)
-		close = "q", -- AI HINTS: Close minimap (inside minimap)
+		toggle = "<leader>mm",
+		focus = "<leader>mf",
+		jump = "<CR>",
+		close = "q",
 	},
-
-	-- AI HINTS: Tree-sitter integration
 	treesitter = {
-		enable = true, -- AI HINTS: Enable Tree-sitter integration
-		highlight_scopes = true, -- AI HINTS: Highlight structural scopes (functions, classes, etc.)
-		-- AI HINTS: Enable Tree-sitter per filetype. This is separate from `filetypes` so you can
-		-- AI HINTS: keep xmap enabled but disable Tree-sitter (or vice versa) per language.
+		enable = true,
+		highlight_scopes = true,
 		languages = get_default_filetypes(),
 	},
-
-	-- AI HINTS: Symbol filtering per language (keyed by filetype)
-	-- AI HINTS: For Swift, this controls which declaration keywords are shown in the minimap.
-	-- AI HINTS: Example: hide properties but keep types + functions:
-	-- AI HINTS: symbols = { swift = { exclude = { "let", "var" } } }
 	symbols = {
 		swift = {
-			keywords = {}, -- AI HINTS: When empty, uses the Swift provider defaults
-			exclude = {}, -- AI HINTS: Keywords to hide (e.g. { "let", "var" })
-			highlight_keywords = {}, -- AI HINTS: Optional override for keyword highlighting list
+			keywords = {},
+			exclude = {},
+			highlight_keywords = {},
 		},
 		typescript = {
-			keywords = {}, -- AI HINTS: When empty, uses the TypeScript provider defaults
+			keywords = {},
 			exclude = {},
 			highlight_keywords = {},
 		},
 		typescriptreact = {
-			keywords = {}, -- AI HINTS: When empty, uses the TSX provider defaults (TypeScript + React hooks)
+			keywords = {},
 			exclude = {},
 			highlight_keywords = {},
 		},
 		lua = {
-			keywords = {}, -- AI HINTS: When empty, uses the Lua provider defaults
+			keywords = {},
 			exclude = {},
 			highlight_keywords = {},
 		},
 		markdown = {
-			keywords = {}, -- AI HINTS: When empty, uses the Markdown provider defaults (H1-H6)
+			keywords = {},
 			exclude = {},
 			highlight_keywords = {},
 		},
 		c = {
-			-- AI HINTS: Empty keyword/highlight arrays intentionally defer to provider-level
-			-- AI HINTS: defaults from `lua/xmap/lang/c.lua`.
-			keywords = {}, -- AI HINTS: When empty, uses the C provider defaults
+			keywords = {},
 			exclude = {},
 			highlight_keywords = {},
 		},
 		cpp = {
-			-- AI HINTS: Empty keyword/highlight arrays intentionally defer to provider-level
-			-- AI HINTS: defaults from `lua/xmap/lang/cpp.lua`.
-			keywords = {}, -- AI HINTS: When empty, uses the C++ provider defaults
+			keywords = {},
 			exclude = {},
 			highlight_keywords = {},
 		},
 	},
-
-	-- AI HINTS: Highlight overrides (applied on setup and on ColorScheme refresh)
-	-- AI HINTS: Example:
-	-- AI HINTS: highlights = { XmapRelativeNumber = { link = "CursorLineNr", bold = true } }
 	highlights = {},
-
-	-- AI HINTS: Rendering options
 	render = {
-		-- AI HINTS: Relative prefix (distance + direction) shown for each minimap line.
-		-- AI HINTS: Default format: ` 12 ↓ ` (number first, direction after).
 		relative_prefix = {
-			-- AI HINTS: Minimum width (in digits) for the distance column.
-			-- AI HINTS: Distances are capped at 999 for consistent alignment.
 			number_width = 4,
-			-- AI HINTS: Inserted between the number and the direction indicator.
-			-- AI HINTS: Example: number_separator=" " produces `12 ↓`, number_separator="" produces `12↓`.
 			number_separator = " ",
-			-- AI HINTS: Inserted after the direction indicator (before icon/text).
-			-- AI HINTS: Example: separator=" " produces `↓ 󰊕 func foo`.
 			separator = " ",
-			-- AI HINTS: Direction indicators can be symbols or key letters (e.g. down="j", up="k").
 			direction = {
 				up = "↑",
 				down = "↓",
 				current = "·",
 			},
 		},
-
-		-- AI HINTS: Maximum number of characters per line in minimap (including prefix)
 		max_line_length = 40,
-
-		-- AI HINTS: Update frequency (milliseconds)
-		-- AI HINTS: Throttle minimap updates to avoid performance issues
 		throttle_ms = 100,
 	},
-
-	-- AI HINTS: Navigation settings
 	navigation = {
-		-- AI HINTS: Show relative line indicator when navigating
 		show_relative_line = true,
-
-		-- AI HINTS: Auto-center main window when jumping
 		auto_center = true,
-
-		-- AI HINTS: While the minimap is focused, keep the main editor cursor centered on the minimap selection.
 		follow_cursor = true,
 	},
 }
-
--- AI HINTS: Current user configuration
 M.options = {}
-
--- PURPOSE: Merge user options over defaults.
 function M.setup(user_config)
 	M.options = vim.tbl_deep_extend("force", M.defaults, user_config or {})
 	return M.options
 end
-
--- AI HINTS: Get current configuration
 function M.get()
 	if vim.tbl_isempty(M.options) then
 		M.options = vim.deepcopy(M.defaults)
@@ -158,16 +101,10 @@ function M.get()
 end
 
 function M.is_filetype_supported(filetype)
-	-- PURPOSE: Return true only when filetype is allowed by config and provider exists.
-	-- CONSTRAINTS: Require both include-list membership and provider availability.
 	local opts = M.get()
-
-	-- AI HINTS: Check if in exclude list
 	if vim.tbl_contains(opts.exclude_filetypes or {}, filetype) then
 		return false
 	end
-
-	-- AI HINTS: Check if in include list
 	if not vim.tbl_contains(opts.filetypes or get_default_filetypes(), filetype) then
 		return false
 	end
@@ -177,7 +114,6 @@ function M.is_filetype_supported(filetype)
 end
 
 function M.is_treesitter_enabled(filetype)
-	-- PURPOSE: Return true only when Tree-sitter is globally enabled and filetype is allowed.
 	local opts = M.get()
 	if not opts.treesitter.enable then
 		return false

--- a/lua/xmap/highlight.lua
+++ b/lua/xmap/highlight.lua
@@ -1,36 +1,20 @@
--- AI HINTS: lua/xmap/highlight.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Highlight group management for xmap.nvim
---
--- AI HINTS: Highlights are a big part of xmap's UX. The goals here are:
--- AI HINTS: - Respect the active colorscheme by linking to existing groups by default.
--- AI HINTS: - Provide safe fallbacks when a theme doesn't define a linked group.
--- AI HINTS: - Allow user overrides via `require("xmap").setup({ highlights = { ... } })`.
--- AI HINTS: - Keep overrides stable across `:colorscheme` by re-applying on ColorScheme.
+-- PURPOSE:
+-- - Define xmap highlight groups and resolve theme-safe fallbacks.
+-- CONSTRAINTS:
+-- - Respect colorscheme links first; fall back only when the resolved group is empty.
 
 local config = require("xmap.config")
 
 local M = {}
 
--- AI HINTS: Define all highlight groups used by xmap
--- AI HINTS: These are the only highlight group names xmap will ever set.
+-- PURPOSE:
+-- - Keep the complete public highlight surface in one map.
 M.groups = {
-	-- AI HINTS: Minimap window background
 	XmapBackground = { link = "Normal" },
-
-	-- AI HINTS: Normal text in minimap (slightly dimmed)
 	XmapText = { link = "Comment" },
-
-	-- AI HINTS: Line numbers in minimap (if enabled)
 	XmapLineNr = { link = "LineNr" },
-
-	-- AI HINTS: Current viewport region (visible area in main buffer)
 	XmapViewport = { link = "Visual", no_fg = true },
-
-	-- AI HINTS: Cursor/selection in minimap
 	XmapCursor = { link = "CursorLine", no_fg = true },
-
-	-- AI HINTS: Tree-sitter scope highlights (will inherit from colorscheme or use fallback)
 	XmapFunction = { link = "@function" },
 	XmapClass = { link = "@type" },
 	XmapMethod = { link = "@method" },
@@ -46,51 +30,41 @@ M.groups = {
 	XmapMarkdownH5 = { link = "Comment" },
 	XmapMarkdownH6 = { link = "Comment" },
 	XmapMarkdownHeadingText = { link = "XmapText" },
-
-	-- AI HINTS: Structural indicators
 	XmapScope = { link = "Title" },
 	XmapBorder = { link = "FloatBorder" },
-
-	-- AI HINTS: Relative distance + direction prefix (derive from theme groups by default).
-	-- AI HINTS: Used by `minimap.apply_relative_number_highlighting`.
 	XmapRelativeUp = { link = "DiagnosticOk", bold = true, no_bg = true },
 	XmapRelativeDown = { link = "DiagnosticError", bold = true, no_bg = true },
 	XmapRelativeCurrent = { link = "DiagnosticWarn", bold = true, no_bg = true },
-	XmapRelativeNumber = { link = "CursorLineNr", bold = false, no_bg = true }, -- AI HINTS: Brighter numbers by default
+	XmapRelativeNumber = { link = "CursorLineNr", bold = false, no_bg = true },
 	XmapRelativeKeyword = { link = "Keyword", bold = true, no_bg = true },
 	XmapRelativeEntity = { link = "Identifier", no_bg = true },
-
-	-- AI HINTS: Comment markers
-	XmapCommentNormal = { link = "Comment", no_bg = true }, -- AI HINTS: Regular comments
-	XmapCommentDoc = { link = "SpecialComment", no_bg = true }, -- AI HINTS: Doc comments (///)
-	XmapCommentBold = { bold = true, no_bg = true }, -- AI HINTS: Bold text for marker descriptions
-	XmapCommentMark = { link = "WarningMsg", bold = true, no_bg = true }, -- AI HINTS: MARK: marker
-	XmapCommentTodo = { link = "WarningMsg", bold = true, no_bg = true }, -- AI HINTS: TODO: marker
-	XmapCommentFixme = { link = "WarningMsg", bold = true, no_bg = true }, -- AI HINTS: FIXME: marker
-	XmapCommentNote = { link = "WarningMsg", bold = true, no_bg = true }, -- AI HINTS: NOTE: marker
-	XmapCommentWarning = { link = "WarningMsg", bold = true, no_bg = true }, -- AI HINTS: WARNING: marker
-	XmapCommentBug = { link = "WarningMsg", bold = true, no_bg = true }, -- AI HINTS: BUG: marker
+	XmapCommentNormal = { link = "Comment", no_bg = true },
+	XmapCommentDoc = { link = "SpecialComment", no_bg = true },
+	XmapCommentBold = { bold = true, no_bg = true },
+	XmapCommentMark = { link = "WarningMsg", bold = true, no_bg = true },
+	XmapCommentTodo = { link = "WarningMsg", bold = true, no_bg = true },
+	XmapCommentFixme = { link = "WarningMsg", bold = true, no_bg = true },
+	XmapCommentNote = { link = "WarningMsg", bold = true, no_bg = true },
+	XmapCommentWarning = { link = "WarningMsg", bold = true, no_bg = true },
+	XmapCommentBug = { link = "WarningMsg", bold = true, no_bg = true },
 }
-
--- AI HINTS: Fallback colors (used only if a linked group does not exist or resolves to empty).
--- AI HINTS: Keep these conservative: the intention is "still readable", not "force a theme".
 local fallback_colors = {
-	XmapFunction = { fg = "#7aa2f7", bold = true }, -- AI HINTS: Blue
-	XmapClass = { fg = "#bb9af7", bold = true }, -- AI HINTS: Purple
-	XmapVariable = { fg = "#9ece6a" }, -- AI HINTS: Green
-	XmapSwiftKeyword = { fg = "#bb9af7" }, -- AI HINTS: Purple
-	XmapRelativeUp = { fg = "#9ece6a", bold = true }, -- AI HINTS: Green
-	XmapRelativeDown = { fg = "#f7768e", bold = true }, -- AI HINTS: Red
-	XmapRelativeCurrent = { fg = "#e0af68", bold = true }, -- AI HINTS: Yellow
-	XmapRelativeNumber = { fg = "#c0caf5", bold = true }, -- AI HINTS: Bright
-	XmapRelativeKeyword = { fg = "#bb9af7", bold = true }, -- AI HINTS: Purple (keywords)
-	XmapRelativeEntity = { fg = "#7dcfff" }, -- AI HINTS: Cyan (entity names)
-	XmapMarkdownH1 = { fg = "#f7768e" }, -- AI HINTS: Red
-	XmapMarkdownH2 = { fg = "#e0af68" }, -- AI HINTS: Yellow
-	XmapMarkdownH3 = { fg = "#9ece6a" }, -- AI HINTS: Green
-	XmapMarkdownH4 = { fg = "#565f89" }, -- AI HINTS: Gray
-	XmapMarkdownH5 = { fg = "#565f89" }, -- AI HINTS: Gray
-	XmapMarkdownH6 = { fg = "#565f89" }, -- AI HINTS: Gray
+	XmapFunction = { fg = "#7aa2f7", bold = true },
+	XmapClass = { fg = "#bb9af7", bold = true },
+	XmapVariable = { fg = "#9ece6a" },
+	XmapSwiftKeyword = { fg = "#bb9af7" },
+	XmapRelativeUp = { fg = "#9ece6a", bold = true },
+	XmapRelativeDown = { fg = "#f7768e", bold = true },
+	XmapRelativeCurrent = { fg = "#e0af68", bold = true },
+	XmapRelativeNumber = { fg = "#c0caf5", bold = true },
+	XmapRelativeKeyword = { fg = "#bb9af7", bold = true },
+	XmapRelativeEntity = { fg = "#7dcfff" },
+	XmapMarkdownH1 = { fg = "#f7768e" },
+	XmapMarkdownH2 = { fg = "#e0af68" },
+	XmapMarkdownH3 = { fg = "#9ece6a" },
+	XmapMarkdownH4 = { fg = "#565f89" },
+	XmapMarkdownH5 = { fg = "#565f89" },
+	XmapMarkdownH6 = { fg = "#565f89" },
 }
 
 local function is_empty(tbl)
@@ -98,8 +72,6 @@ local function is_empty(tbl)
 end
 
 local function get_resolved_hl(name)
-	-- AI HINTS: Request the fully-resolved highlight definition (no link indirection). If a theme
-	-- AI HINTS: does not define the group, Neovim returns an empty table.
 	local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = name, link = false })
 	if not ok or is_empty(hl) then
 		return nil
@@ -108,9 +80,6 @@ local function get_resolved_hl(name)
 end
 
 local function apply_overrides(base, overrides)
-	-- AI HINTS: Merge highlight definitions while supporting our convenience flags:
-	-- AI HINTS: - `no_bg`: clear background even when the linked group has one
-	-- AI HINTS: - `no_fg`: clear foreground even when the linked group has one
 	local out = vim.deepcopy(base or {})
 	for k, v in pairs(overrides or {}) do
 		if k ~= "link" and k ~= "no_bg" and k ~= "no_fg" then
@@ -166,11 +135,8 @@ local function adjust_color(color, amount)
 end
 
 local function derive_cursor_bg()
-	-- AI HINTS: Derive a visible cursor background color when the colorscheme doesn't provide one.
-	-- AI HINTS: Many transparent themes leave CursorLine.bg unset, so we try a few options:
-	-- AI HINTS: 1) CursorLine.bg
-	-- AI HINTS: 2) Visual.bg (often a good contrast)
-	-- AI HINTS: 3) a slight luminance adjustment of Normal.bg
+	-- DO:
+	-- - Prefer an existing visible theme background before synthesizing one.
 	local cursor = get_resolved_hl("CursorLine")
 	local visual = get_resolved_hl("Visual")
 	local normal = get_resolved_hl("Normal")
@@ -194,8 +160,6 @@ local function derive_cursor_bg()
 end
 
 local function get_highlight_overrides()
-	-- AI HINTS: User overrides live in config (`opts.highlights`). We read them here so `M.setup()`
-	-- AI HINTS: can reapply everything on demand (e.g. after ColorScheme).
 	local opts = config.get()
 	if type(opts.highlights) ~= "table" then
 		return {}
@@ -204,10 +168,8 @@ local function get_highlight_overrides()
 end
 
 local function normalize_override(value)
-	-- AI HINTS: Convenience: allow both
-	-- AI HINTS: highlights = { XmapText = "Comment" }
-	-- AI HINTS: and
-	-- AI HINTS: highlights = { XmapText = { link = "Comment", italic = true } }
+	-- PURPOSE:
+	-- - Accept either `link` shorthand or a full override table.
 	if type(value) == "string" then
 		return { link = value }
 	end
@@ -216,14 +178,7 @@ local function normalize_override(value)
 	end
 	return nil
 end
-
--- AI HINTS: Setup highlight groups
 function M.setup()
-	-- AI HINTS: Called on plugin setup and on ColorScheme changes.
-	-- AI HINTS: For each group:
-	-- AI HINTS: - resolve the linked highlight (if it exists)
-	-- AI HINTS: - apply fallback colors when missing
-	-- AI HINTS: - layer user overrides on top
 	local overrides = get_highlight_overrides()
 	for group_name, group_def in pairs(M.groups) do
 		local user_override = normalize_override(overrides[group_name])
@@ -233,8 +188,6 @@ function M.setup()
 		end
 
 		if group_name == "XmapCursor" and def.link then
-			-- AI HINTS: Special-case: ensure the minimap cursor highlight is visible even on
-			-- AI HINTS: transparent themes where CursorLine has no bg.
 			local link_name = def.link
 			local link_hl = get_resolved_hl(link_name) or {}
 			local resolved = apply_overrides(link_hl, def)
@@ -265,35 +218,17 @@ function M.setup()
 		end
 	end
 end
-
--- AI HINTS: Apply highlight to a buffer region
--- INPUT: bufnr number: Buffer number
--- INPUT: ns_id number: Namespace ID
--- INPUT: hl_group string: Highlight group name
--- INPUT: line number: Line number (0-indexed)
--- INPUT: col_start number: Start column (0-indexed)
--- INPUT: col_end number: End column (-1 for end of line)
 function M.apply(bufnr, ns_id, hl_group, line, col_start, col_end)
-	-- AI HINTS: Highlights are best-effort. A bad range should not break the minimap update loop.
 	pcall(vim.api.nvim_buf_add_highlight, bufnr, ns_id, hl_group, line, col_start, col_end)
 end
-
--- AI HINTS: Clear highlights in buffer
 function M.clear(bufnr, ns_id, line_start, line_end)
-	-- AI HINTS: Clear an entire namespace (or a range) before re-applying highlights.
 	line_start = line_start or 0
 	line_end = line_end or -1
 	pcall(vim.api.nvim_buf_clear_namespace, bufnr, ns_id, line_start, line_end)
 end
-
--- AI HINTS: Create a namespace for xmap highlights
 function M.create_namespace(name)
-	-- AI HINTS: Namespaces isolate different highlight layers (viewport/cursor/syntax/structure)
-	-- AI HINTS: so they can be cleared independently.
 	return vim.api.nvim_create_namespace("xmap_" .. name)
 end
-
--- AI HINTS: Refresh all highlight groups (useful when colorscheme changes)
 function M.refresh()
 	M.setup()
 end

--- a/lua/xmap/init.lua
+++ b/lua/xmap/init.lua
@@ -1,45 +1,22 @@
--- AI HINTS: lua/xmap/init.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- PURPOSE: Public API entrypoint for xmap plugin lifecycle and commands.
--- INPUT: User config via `setup(opts)` and command-driven calls (`open`, `toggle`, `focus`).
--- OUTPUT: Stable API surface wrapping internal modules.
--- DEPENDENCIES: config, highlight, treesitter, minimap, navigation modules.
--- CONSTRAINTS: Keep API backward-compatible for user init.lua and exposed commands.
--- STABILITY: Core
+
+-- PURPOSE:
+-- - Expose the public xmap API and wire core modules on setup.
+-- CONSTRAINTS:
+-- - Keep lazy-init behavior for direct API calls before `setup()`.
 
 local M = {}
-
--- AI HINTS: Module references
 local config = require("xmap.config")
 local highlight = require("xmap.highlight")
 local treesitter = require("xmap.treesitter")
 local minimap = require("xmap.minimap")
 local navigation = require("xmap.navigation")
-
--- AI HINTS: Plugin state
 M._initialized = false
-
--- AI HINTS: Setup function
--- INPUT: opts table: User configuration options
 function M.setup(opts)
-  -- AI HINTS: Idempotent: safe to call multiple times, but users typically call once from init.lua.
-  -- AI HINTS: Merge user config with defaults
   config.setup(opts or {})
-
-  -- AI HINTS: Initialize highlight groups
   highlight.setup()
-
-  -- AI HINTS: Initialize Tree-sitter if available
   treesitter.setup()
-
-  -- AI HINTS: Set up global keymaps if configured
   M.setup_global_keymaps()
-
-  -- AI HINTS: Set up autocommands for auto-open
   M.setup_auto_open()
-
-  -- AI HINTS: Refresh highlights on colorscheme change
-  -- AI HINTS: (re-apply links/fallbacks and user overrides).
   vim.api.nvim_create_autocmd("ColorScheme", {
     pattern = "*",
     callback = function()
@@ -49,43 +26,30 @@ function M.setup(opts)
 
   M._initialized = true
 end
-
--- AI HINTS: Set up global keymaps
 function M.setup_global_keymaps()
   local opts = config.get()
-
-  -- AI HINTS: Toggle keymap
   if opts.keymaps.toggle then
     vim.keymap.set("n", opts.keymaps.toggle, function()
       M.toggle()
     end, { silent = true, desc = "Toggle Xmap minimap" })
   end
-
-  -- AI HINTS: Focus keymap
   if opts.keymaps.focus then
     vim.keymap.set("n", opts.keymaps.focus, function()
       M.focus()
     end, { silent = true, desc = "Focus Xmap minimap" })
   end
 end
-
--- AI HINTS: Set up auto-open functionality
 function M.setup_auto_open()
   local opts = config.get()
 
   if not opts.auto_open then
     return
   end
-
-  -- AI HINTS: Auto-open minimap for supported filetypes
   vim.api.nvim_create_autocmd({ "BufEnter", "FileType" }, {
     pattern = "*",
     callback = function()
       local filetype = vim.bo.filetype
-
-      -- AI HINTS: Check if filetype is supported
       if config.is_filetype_supported(filetype) then
-        -- AI HINTS: Only open if not already open
         if not minimap.is_open() then
           M.open()
         end
@@ -93,85 +57,57 @@ function M.setup_auto_open()
     end,
   })
 end
-
--- AI HINTS: Open minimap
 function M.open()
-  -- AI HINTS: Lazy-initialize if user calls API before `setup()`.
   if not M._initialized then
     M.setup()
   end
 
   minimap.open()
 end
-
--- AI HINTS: Close minimap
 function M.close()
   minimap.close()
 end
-
--- AI HINTS: Toggle minimap
 function M.toggle()
-  -- AI HINTS: Lazy-initialize if user calls API before `setup()`.
   if not M._initialized then
     M.setup()
   end
 
   minimap.toggle()
 end
-
--- AI HINTS: Refresh minimap (force redraw)
 function M.refresh()
   if minimap.is_open() then
     minimap.update()
   end
 end
-
--- AI HINTS: Focus minimap window
 function M.focus()
-  -- AI HINTS: Lazy-initialize if user calls API before `setup()`.
   if not M._initialized then
     M.setup()
   end
-
-  -- AI HINTS: Focus should be a convenience: open the minimap if needed, then focus it.
   if not (minimap.is_open() and minimap.state.winid and vim.api.nvim_win_is_valid(minimap.state.winid)) then
     M.open()
   end
-
-  -- AI HINTS: Opening can fail (e.g. unsupported filetype), so check again.
   if not (minimap.is_open() and minimap.state.winid and vim.api.nvim_win_is_valid(minimap.state.winid)) then
     return
   end
 
   navigation.focus_minimap(minimap.state.winid)
 end
-
--- AI HINTS: Check if minimap is open
--- OUTPUT: boolean
 function M.is_open()
   return minimap.is_open()
 end
-
--- AI HINTS: Get current configuration
--- OUTPUT: table: Current configuration
 function M.get_config()
   return config.get()
 end
-
--- AI HINTS: Update configuration at runtime
--- INPUT: opts table: Configuration options to update
 function M.update_config(opts)
   local current = config.get()
   config.options = vim.tbl_deep_extend("force", current, opts or {})
-
-  -- AI HINTS: Refresh if minimap is open
   if minimap.is_open() then
     M.refresh()
   end
 end
-
--- AI HINTS: Diagnostic function to test Tree-sitter detection
 function M.diagnose()
+  -- PURPOSE:
+  -- - Print enough parser/query state to debug Tree-sitter mismatches.
   local bufnr = vim.api.nvim_get_current_buf()
   local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
   local ts_lang = filetype
@@ -182,12 +118,8 @@ function M.diagnose()
   print("=== xmap.nvim Diagnostics ===")
   print("Filetype: " .. filetype)
   print("Tree-sitter language: " .. ts_lang)
-  
-  -- AI HINTS: Check if nvim-treesitter is available
   local ts_ok, _ = pcall(require, "nvim-treesitter")
   print("nvim-treesitter available: " .. tostring(ts_ok))
-  
-  -- AI HINTS: Check if parser is available
   local parser = vim.treesitter.get_parser(bufnr, nil, { error = false })
   print("Tree-sitter parser for " .. filetype .. ": " .. tostring(parser ~= nil))
   
@@ -196,8 +128,6 @@ function M.diagnose()
     print("Install with: :TSInstall " .. ts_lang)
     return
   end
-  
-  -- AI HINTS: Try to parse
   local ok, trees = pcall(function() return parser:parse() end)
   print("Parse successful: " .. tostring(ok))
   
@@ -205,8 +135,6 @@ function M.diagnose()
     print("ERROR: Failed to parse buffer")
     return
   end
-  
-  -- AI HINTS: Check structural nodes
   local treesitter = require("xmap.treesitter")
   local nodes = treesitter.get_structural_nodes(bufnr, filetype)
   print("Structural nodes found: " .. #nodes)
@@ -223,22 +151,17 @@ function M.diagnose()
     print("  1. The Tree-sitter query doesn't match any nodes")
     print("  2. The parser node names are different")
     print("  3. The buffer is empty or has no structural elements")
-
-    -- AI HINTS: Recursively search for all declaration nodes
     print("\nSearching entire tree for function/property declarations:")
     local function find_declarations(node, depth)
-      if depth > 10 then return end -- AI HINTS: Prevent infinite recursion
+      if depth > 10 then return end
 
       local node_type = node:type()
-      -- AI HINTS: Look for anything that might be a function or property
       if node_type:match("function") or node_type:match("property") or
          node_type:match("method") or node_type:match("init") or
          node_type:match("variable") or node_type:match("constant") then
         local start_row = node:start()
         print(string.format("  Line %d: %s", start_row + 1, node_type))
       end
-
-      -- AI HINTS: Recursively check children
       for i = 0, node:child_count() - 1 do
         local child = node:child(i)
         if child then
@@ -248,11 +171,7 @@ function M.diagnose()
     end
 
     find_declarations(trees[1]:root(), 0)
-
-    -- AI HINTS: Try to inspect the tree
     print("\nTree root type: " .. trees[1]:root():type())
-    
-    -- AI HINTS: Try to get first few children
     local root = trees[1]:root()
     print("Root has " .. root:child_count() .. " children")
     if root:child_count() > 0 then
@@ -262,8 +181,6 @@ function M.diagnose()
         if child then
           local start_row = child:start()
           print(string.format("  Line %d: %s (has %d children)", start_row + 1, child:type(), child:child_count()))
-
-          -- AI HINTS: If this is a class/struct, show its children
           if child:type():match("declaration") and child:child_count() > 0 then
             print("    Children of " .. child:type() .. ":")
             for j = 0, math.min(9, child:child_count() - 1) do
@@ -281,8 +198,6 @@ function M.diagnose()
   
   print("=== End Diagnostics ===")
 end
-
--- PURPOSE: Semantic plugin version exposed for diagnostics/tooling.
 M.version = "0.8.2"
 
 return M

--- a/lua/xmap/lang/c.lua
+++ b/lua/xmap/lang/c.lua
@@ -1,14 +1,8 @@
--- AI HINTS: lua/xmap/lang/c.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- PURPOSE: Provide C-language symbol/comment extraction for xmap minimap.
--- DEPENDENCIES: Neovim Lua API (`vim.*`) and xmap language loader.
--- CONSTRAINTS: Keep provider pure; no buffer/window mutation.
--- STABILITY: Core
+
+-- PURPOSE:
+-- - Parse C declarations/comments for minimap rendering.
 
 local M = {}
-
--- PURPOSE: Default symbol classes used when user config does not override `symbols.c.keywords`.
--- OUTPUT: Ordered keyword list consumed by symbol filtering/highlighting.
 M.default_symbol_keywords = {
 	"function",
 	"struct",
@@ -29,12 +23,9 @@ local CONTROL_KEYWORDS = {
 	["return"] = true,
 	["sizeof"] = true,
 }
-
--- PURPOSE: Query fallbacks ordered from richest -> most compatible.
--- DO: Keep first variant as preferred parse surface.
--- DO NOT: Remove fallback variant without parser-compat evidence.
--- STABILITY: Flexible
 local QUERY_VARIANTS = {
+	-- CONSTRAINTS:
+	-- - Keep a compatibility fallback for narrower C grammars.
 	[[
     (function_definition) @function
     (struct_specifier) @class
@@ -61,15 +52,9 @@ end
 local function ltrim(text)
 	return (text:gsub("^%s+", ""))
 end
-
--- PURPOSE: Normalize declaration prefixes before pattern-based symbol parsing.
--- INPUT: Raw source line text.
--- OUTPUT: Same line without known leading declaration modifiers.
--- ALGORITHM:
--- AI HINTS: - Trim leading whitespace.
--- AI HINTS: - Iteratively strip known modifiers until no change.
--- CONSTRAINTS: Strip only leading tokens; preserve semantic tail.
 local function strip_modifiers(text)
+	-- PURPOSE:
+	-- - Remove leading declaration modifiers before pattern matching.
 	local out = ltrim(text)
 	local changed = true
 	while changed do
@@ -99,21 +84,12 @@ local function strip_modifiers(text)
 end
 
 function M.parse_symbol(line_text)
-	-- PURPOSE: Map one C line to a minimap symbol descriptor or nil.
-	-- INPUT: `line_text` (string|nil), may include modifiers/comments/spacing noise.
-	-- OUTPUT: Table `{ keyword, capture_type, display }` or nil.
-	-- DO:
-	-- AI HINTS: - Prefer explicit constructs (`#define`, `return`, type declarations).
-	-- AI HINTS: - Avoid control keywords as function names.
-	-- CONSTRAINTS: Pattern-only parser; no Tree-sitter dependency here.
-	-- AI HINTS: Extend by adding guarded parsing blocks; do not reorder broad regexes before specific cases.
 	local cleaned = strip_modifiers(line_text or "")
 	if cleaned == "" then
 		return nil
 	end
 
 	do
-		-- PURPOSE: Render preprocessor define as navigable symbol.
 		local macro = cleaned:match("^#%s*define%s+([%w_]+)")
 		if macro then
 			return { keyword = "define", capture_type = "variable", display = "#define " .. macro }
@@ -121,7 +97,6 @@ function M.parse_symbol(line_text)
 	end
 
 	if cleaned == "return" or cleaned:match("^return%f[%W]") then
-		-- PURPOSE: Surface control-flow return markers with optional tail expression.
 		local rest = vim.trim((cleaned:gsub("^return", "", 1))):gsub(";+$", "")
 		local display = "return"
 		if rest ~= "" then
@@ -131,7 +106,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect named type declarations.
 		local keyword, name = cleaned:match("^(struct)%s+([%w_]+)")
 			or cleaned:match("^(union)%s+([%w_]+)")
 			or cleaned:match("^(enum)%s+([%w_]+)")
@@ -141,7 +115,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect typedef aliases as type symbols.
 		local alias = cleaned:match("^typedef%s+.-([%w_]+)%s*;")
 		if alias then
 			return { keyword = "typedef", capture_type = "class", display = "typedef " .. alias }
@@ -149,7 +122,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect untyped/simple function signatures.
 		local name = cleaned:match("^([%a_][%w_]*)%s*%b()%s*[{;]")
 		if name and not CONTROL_KEYWORDS[name] then
 			return { keyword = "function", capture_type = "function", display = "function " .. name }
@@ -157,7 +129,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect typed function signatures (incl. pointer-heavy declarations).
 		local name = cleaned:match("^[%w_%s%*]+%s+([%a_][%w_]*)%s*%b()%s*[{;]")
 		if name and not CONTROL_KEYWORDS[name] then
 			return { keyword = "function", capture_type = "function", display = "function " .. name }
@@ -168,9 +139,6 @@ function M.parse_symbol(line_text)
 end
 
 function M.is_comment_line(trimmed)
-	-- PURPOSE: Fast gate for comment-line rendering path.
-	-- INPUT: Trimmed line.
-	-- OUTPUT: Boolean.
 	return trimmed:match("^//")
 		or trimmed:match("^/%*")
 		or trimmed:match("^%*/")
@@ -179,10 +147,8 @@ function M.is_comment_line(trimmed)
 end
 
 function M.extract_comment(line)
-	-- PURPOSE: Normalize comment text and marker metadata for minimap rendering.
-	-- INPUT: Raw line.
-	-- OUTPUT: `text, marker, false, raw_text` or nil tuple.
-	-- CONSTRAINTS: Keep output shape compatible with existing provider interface.
+	-- PURPOSE:
+	-- - Normalize C comment text and marker prefixes for rendering.
 	local trimmed = vim.trim(line)
 	local text = trimmed:gsub("^//+%s*", ""):gsub("^/%*+%s*", ""):gsub("^%*+%s*", ""):gsub("%s*%*/$", "")
 	if text == "" then
@@ -190,7 +156,6 @@ function M.extract_comment(line)
 	end
 
 	local marker = nil
-	-- DO: Parse marker prefixes used by current highlight contract.
 	if text:match("^TODO:") then
 		marker = "TODO"
 		text = text:gsub("^TODO:%s*", "")
@@ -212,7 +177,6 @@ function M.extract_comment(line)
 	end
 
 	local raw_text = text
-	-- CONSTRAINTS: Keep minimap rows compact; preserve non-truncated `raw_text`.
 	if #text > 35 then
 		text = text:sub(1, 32) .. "..."
 	end
@@ -221,8 +185,8 @@ function M.extract_comment(line)
 end
 
 function M.render_comment(line)
-	-- PURPOSE: Convert extracted comment tuple into renderer-ready payload.
-	-- OUTPUT: `{ kind=\"marker\"|\"comment\", ... }` or nil.
+	-- PURPOSE:
+	-- - Render either a marker or a plain comment entry.
 	local text, marker = M.extract_comment(line)
 	if marker then
 		return { kind = "marker", marker = marker, text = text or "" }

--- a/lua/xmap/lang/cc.lua
+++ b/lua/xmap/lang/cc.lua
@@ -1,5 +1,3 @@
--- AI HINTS: lua/xmap/lang/cc.lua
--- PURPOSE: Alias `cc` filetype to canonical C++ provider.
--- CONSTRAINTS: No custom logic; keep passthrough require only.
--- STABILITY: Core
+-- PURPOSE:
+-- - Alias `cc` to the C++ provider.
 return require("xmap.lang.cpp")

--- a/lua/xmap/lang/cpp.lua
+++ b/lua/xmap/lang/cpp.lua
@@ -1,14 +1,8 @@
--- AI HINTS: lua/xmap/lang/cpp.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- PURPOSE: Provide C++ symbol/comment extraction for xmap minimap.
--- DEPENDENCIES: Neovim Lua API (`vim.*`) and xmap language loader.
--- CONSTRAINTS: Keep provider pure; no buffer/window mutation.
--- STABILITY: Core
+
+-- PURPOSE:
+-- - Parse C++ declarations/comments for minimap rendering.
 
 local M = {}
-
--- PURPOSE: Default symbol classes used when user config does not override `symbols.cpp.keywords`.
--- OUTPUT: Ordered keyword list consumed by symbol filtering/highlighting.
 M.default_symbol_keywords = {
 	"function",
 	"method",
@@ -35,12 +29,9 @@ local CONTROL_KEYWORDS = {
 	["new"] = true,
 	["delete"] = true,
 }
-
--- PURPOSE: Query fallbacks ordered from richest -> most compatible.
--- DO: Keep first variant as preferred parse surface.
--- DO NOT: Remove fallback variant without parser-compat evidence.
--- STABILITY: Flexible
 local QUERY_VARIANTS = {
+	-- CONSTRAINTS:
+	-- - Keep a compatibility fallback for parser/version drift.
 	[[
     (function_definition) @function
     (class_specifier) @class
@@ -69,15 +60,9 @@ end
 local function ltrim(text)
 	return (text:gsub("^%s+", ""))
 end
-
--- PURPOSE: Normalize declaration prefixes before pattern-based symbol parsing.
--- INPUT: Raw source line text.
--- OUTPUT: Same line without known leading declaration modifiers.
--- ALGORITHM:
--- AI HINTS: - Trim leading whitespace.
--- AI HINTS: - Iteratively strip known modifiers until no change.
--- CONSTRAINTS: Strip only leading tokens; preserve semantic tail.
 local function strip_modifiers(text)
+	-- PURPOSE:
+	-- - Remove leading declaration modifiers before pattern matching.
 	local out = ltrim(text)
 	local patterns = {
 		"^(static)%s+",
@@ -107,21 +92,12 @@ local function strip_modifiers(text)
 end
 
 function M.parse_symbol(line_text)
-	-- PURPOSE: Map one C++ line to a minimap symbol descriptor or nil.
-	-- INPUT: `line_text` (string|nil), may include modifiers/comments/spacing noise.
-	-- OUTPUT: Table `{ keyword, capture_type, display }` or nil.
-	-- DO:
-	-- AI HINTS: - Prefer explicit constructs (`#define`, `namespace`, `class`, aliases, methods).
-	-- AI HINTS: - Avoid control keywords as function names.
-	-- CONSTRAINTS: Pattern-only parser; no Tree-sitter dependency here.
-	-- AI HINTS: Extend by adding guarded parsing blocks; keep scoped-method detection before generic function patterns.
 	local cleaned = strip_modifiers(line_text or "")
 	if cleaned == "" then
 		return nil
 	end
 
 	do
-		-- PURPOSE: Render preprocessor define as navigable symbol.
 		local macro = cleaned:match("^#%s*define%s+([%w_]+)")
 		if macro then
 			return { keyword = "define", capture_type = "variable", display = "#define " .. macro }
@@ -129,7 +105,6 @@ function M.parse_symbol(line_text)
 	end
 
 	if cleaned == "return" or cleaned:match("^return%f[%W]") then
-		-- PURPOSE: Surface control-flow return markers with optional tail expression.
 		local rest = vim.trim((cleaned:gsub("^return", "", 1))):gsub(";+$", "")
 		local display = "return"
 		if rest ~= "" then
@@ -139,7 +114,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect namespace declarations.
 		local name = cleaned:match("^namespace%s+([%w_]+)")
 		if name then
 			return { keyword = "namespace", capture_type = "class", display = "namespace " .. name }
@@ -147,7 +121,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect named type declarations.
 		local keyword, name = cleaned:match("^(class)%s+([%w_]+)")
 			or cleaned:match("^(struct)%s+([%w_]+)")
 			or cleaned:match("^(union)%s+([%w_]+)")
@@ -158,7 +131,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect `using` aliases.
 		local alias = cleaned:match("^using%s+([%w_]+)%s*=")
 		if alias then
 			return { keyword = "using", capture_type = "class", display = "using " .. alias }
@@ -166,7 +138,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect `typedef` aliases.
 		local alias = cleaned:match("^typedef%s+.-([%w_]+)%s*;")
 		if alias then
 			return { keyword = "typedef", capture_type = "class", display = "typedef " .. alias }
@@ -174,7 +145,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect scoped methods and classify separately from free functions.
 		local scoped = cleaned:match("([%w_~]+::[%w_~]+)%s*%b()%s*[{;]")
 		if scoped then
 			return { keyword = "method", capture_type = "method", display = "method " .. scoped }
@@ -182,7 +152,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect unqualified function-like signatures.
 		local name = cleaned:match("^([%a_~][%w_~]*)%s*%b()%s*[{;]")
 		if name and not CONTROL_KEYWORDS[name] then
 			return { keyword = "function", capture_type = "function", display = "function " .. name }
@@ -190,7 +159,6 @@ function M.parse_symbol(line_text)
 	end
 
 	do
-		-- PURPOSE: Detect typed function signatures (incl. templates/pointers/references).
 		local name = cleaned:match("^[%w_%s%*&:<>,~]+%s+([%a_~][%w_~]*)%s*%b()%s*[{;]")
 		if name and not CONTROL_KEYWORDS[name] then
 			return { keyword = "function", capture_type = "function", display = "function " .. name }
@@ -201,9 +169,6 @@ function M.parse_symbol(line_text)
 end
 
 function M.is_comment_line(trimmed)
-	-- PURPOSE: Fast gate for comment-line rendering path.
-	-- INPUT: Trimmed line.
-	-- OUTPUT: Boolean.
 	return trimmed:match("^//")
 		or trimmed:match("^/%*")
 		or trimmed:match("^%*/")
@@ -212,10 +177,8 @@ function M.is_comment_line(trimmed)
 end
 
 function M.extract_comment(line)
-	-- PURPOSE: Normalize comment text and marker metadata for minimap rendering.
-	-- INPUT: Raw line.
-	-- OUTPUT: `text, marker, false, raw_text` or nil tuple.
-	-- CONSTRAINTS: Keep output shape compatible with existing provider interface.
+	-- PURPOSE:
+	-- - Normalize C++ comment text and marker prefixes for rendering.
 	local trimmed = vim.trim(line)
 	local text = trimmed:gsub("^//+%s*", ""):gsub("^/%*+%s*", ""):gsub("^%*+%s*", ""):gsub("%s*%*/$", "")
 	if text == "" then
@@ -223,7 +186,6 @@ function M.extract_comment(line)
 	end
 
 	local marker = nil
-	-- DO: Parse marker prefixes used by current highlight contract.
 	if text:match("^TODO:") then
 		marker = "TODO"
 		text = text:gsub("^TODO:%s*", "")
@@ -245,7 +207,6 @@ function M.extract_comment(line)
 	end
 
 	local raw_text = text
-	-- CONSTRAINTS: Keep minimap rows compact; preserve non-truncated `raw_text`.
 	if #text > 35 then
 		text = text:sub(1, 32) .. "..."
 	end
@@ -254,8 +215,8 @@ function M.extract_comment(line)
 end
 
 function M.render_comment(line)
-	-- PURPOSE: Convert extracted comment tuple into renderer-ready payload.
-	-- OUTPUT: `{ kind=\"marker\"|\"comment\", ... }` or nil.
+	-- PURPOSE:
+	-- - Render either a marker or a plain comment entry.
 	local text, marker = M.extract_comment(line)
 	if marker then
 		return { kind = "marker", marker = marker, text = text or "" }

--- a/lua/xmap/lang/cxx.lua
+++ b/lua/xmap/lang/cxx.lua
@@ -1,5 +1,3 @@
--- AI HINTS: lua/xmap/lang/cxx.lua
--- PURPOSE: Alias `cxx` filetype to canonical C++ provider.
--- CONSTRAINTS: No custom logic; keep passthrough require only.
--- STABILITY: Core
+-- PURPOSE:
+-- - Alias `cxx` to the C++ provider.
 return require("xmap.lang.cpp")

--- a/lua/xmap/lang/h.lua
+++ b/lua/xmap/lang/h.lua
@@ -1,6 +1,5 @@
--- AI HINTS: lua/xmap/lang/h.lua
--- PURPOSE: Alias `h` headers to C provider by default.
--- DO: Preserve legacy C-header behavior as default mapping.
--- AI HINTS: If project expects C++ semantics for `.h`, override filetype mapping in user config.
--- STABILITY: Flexible
+-- PURPOSE:
+-- - Alias `.h` to the C provider by default.
+-- CONSTRAINTS:
+-- - Preserve legacy C-header behavior unless user config remaps the filetype.
 return require("xmap.lang.c")

--- a/lua/xmap/lang/hpp.lua
+++ b/lua/xmap/lang/hpp.lua
@@ -1,5 +1,3 @@
--- AI HINTS: lua/xmap/lang/hpp.lua
--- PURPOSE: Alias `hpp` headers to C++ provider.
--- CONSTRAINTS: No custom logic; keep passthrough require only.
--- STABILITY: Core
+-- PURPOSE:
+-- - Alias `.hpp` to the C++ provider.
 return require("xmap.lang.cpp")

--- a/lua/xmap/lang/init.lua
+++ b/lua/xmap/lang/init.lua
@@ -1,29 +1,7 @@
--- AI HINTS: lua/xmap/lang/init.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Language provider registry for xmap.nvim.
---
--- AI HINTS: This module is the "plug-in point" for language-specific logic.
--- AI HINTS: The core minimap logic (rendering, navigation, highlighting) is language-agnostic and
--- AI HINTS: calls into a provider module when it needs to:
--- AI HINTS: - interpret a source line as a "symbol" entry (e.g. `func foo`)
--- AI HINTS: - decide whether a line is a comment / marker
--- AI HINTS: - provide Tree-sitter query strings for structural highlighting
---
--- AI HINTS: A provider module lives at: `lua/xmap/lang/<filetype>.lua`
--- AI HINTS: where `<filetype>` matches `vim.bo.filetype` (e.g. "swift").
---
--- AI HINTS: Provider interface (all are optional, but the minimap needs `parse_symbol` for symbols):
--- AI HINTS: - `default_symbol_keywords` (string[]) default visible keywords for this language.
--- AI HINTS: - `default_highlight_keywords` (string[]) keywords to highlight at line start.
--- AI HINTS: - `get_query()` (string) primary Tree-sitter query (optional).
--- AI HINTS: - `get_queries()` (string[]) query candidates (newest-first) for fallback parsing (optional).
--- AI HINTS: - `parse_symbol(line_text, line_nr?, all_lines?)` -> { keyword, capture_type, display, icon? }|nil
--- AI HINTS: - `is_comment_line(trimmed_line)` -> boolean
--- AI HINTS: - `render_comment(line, line_nr, all_lines)` -> { kind, marker?, text? }|nil
--- AI HINTS: - `extract_comment(line)` -> text|nil, marker|nil, is_doc_comment:boolean, raw_text|nil (optional helper)
---
--- AI HINTS: Adding a new language does not require touching any core modules:
--- AI HINTS: just add a provider file and list its filetype in `require("xmap").setup({ filetypes = {...} })`.
+-- PURPOSE:
+-- - Lazily load and cache language providers by filetype.
+-- CONSTRAINTS:
+-- - Cache misses too, so repeated unsupported lookups stay cheap.
 
 local M = {}
 
@@ -33,8 +11,6 @@ local function load_provider(filetype)
   if type(filetype) ~= "string" or filetype == "" then
     return nil
   end
-
-  -- AI HINTS: Providers are loaded lazily on first use to keep startup fast.
   local ok, mod = pcall(require, "xmap.lang." .. filetype)
   if not ok or type(mod) ~= "table" then
     return nil
@@ -42,12 +18,7 @@ local function load_provider(filetype)
 
   return mod
 end
-
--- AI HINTS: -Get the language provider for a filetype.
--- AI HINTS: -@param filetype string
--- AI HINTS: -@return table|nil
 function M.get(filetype)
-  -- AI HINTS: Cache the result (including failures) so we don't repeatedly `require()` the same module.
   if providers[filetype] ~= nil then
     return providers[filetype] or nil
   end
@@ -56,10 +27,6 @@ function M.get(filetype)
   providers[filetype] = provider or false
   return provider
 end
-
--- AI HINTS: -Check whether a filetype is supported by a bundled/installed provider module.
--- AI HINTS: -@param filetype string
--- AI HINTS: -@return boolean
 function M.supports(filetype)
   return M.get(filetype) ~= nil
 end

--- a/lua/xmap/lang/lua.lua
+++ b/lua/xmap/lang/lua.lua
@@ -1,14 +1,5 @@
--- AI HINTS: lua/xmap/lang/lua.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Lua language support for xmap.nvim
---
--- AI HINTS: This provider implements Lua-specific logic required by the core minimap renderer:
--- AI HINTS: - A set of default declaration keywords to show in the minimap (function/local function/...)
--- AI HINTS: - A Tree-sitter query to obtain structural node ranges for highlighting
--- AI HINTS: - A lightweight line-based parser (`parse_symbol`) that turns a source line into:
--- AI HINTS: { keyword = "...", capture_type = "...", display = "..." }
--- AI HINTS: where `capture_type` matches the generic icon/highlight maps in `treesitter.lua`.
--- AI HINTS: - Comment detection and rendering (including TODO/FIXME style markers)
+-- PURPOSE:
+-- - Parse Lua symbols/comments for minimap rendering and Tree-sitter fallbacks.
 
 local M = {}
 
@@ -25,43 +16,30 @@ local function ltrim(text)
 end
 
 local QUERY_VARIANTS = {
-  -- AI HINTS: Modern Lua parser
+  -- CONSTRAINTS:
+  -- - Order queries from richest to most compatible.
   [[
     (function_declaration) @function
     (local_function) @function
     (field) @variable
     (variable_declaration) @variable
   ]],
-
-  -- AI HINTS: Minimal fallback
   [[
     (function_declaration) @function
     (local_function) @function
   ]],
 }
-
--- AI HINTS: -Get Tree-sitter query candidates for Lua (newest-first).
--- AI HINTS: -@return string[]
 function M.get_queries()
   return QUERY_VARIANTS
 end
-
--- AI HINTS: -Get the primary Tree-sitter query string for Lua.
--- AI HINTS: -@return string
 function M.get_query()
   return QUERY_VARIANTS[1]
 end
-
--- AI HINTS: -Parse a Lua declaration line into a symbol item.
--- AI HINTS: -@param line_text string
--- AI HINTS: -@return {keyword:string, capture_type:string, display:string}|nil
 function M.parse_symbol(line_text)
   local cleaned = ltrim(line_text or "")
   if cleaned == "" then
     return nil
   end
-
-  -- AI HINTS: return statements
   if cleaned == "return" or cleaned:match("^return%f[%W]") then
     local rest = vim.trim((cleaned:gsub("^return", "", 1)))
     local display = "return"
@@ -70,44 +48,33 @@ function M.parse_symbol(line_text)
     end
     return { keyword = "return", capture_type = "function", display = display }
   end
-
-  -- AI HINTS: local function declarations: `local function foo(...)`
   do
     local name = cleaned:match("^local%s+function%s+([%w_%.]+)")
     if name then
       return { keyword = "function", capture_type = "function", display = "local function " .. name }
     end
   end
-
-  -- AI HINTS: global function declarations: `function foo(...)` or `function module.foo(...)`
   do
     local name = cleaned:match("^function%s+([%w_%.]+)")
     if name then
       return { keyword = "function", capture_type = "function", display = "function " .. name }
     end
   end
-
-  -- AI HINTS: local variable declarations: `local foo = ...` or `local foo, bar = ...`
   do
     local names = cleaned:match("^local%s+([%w_,%s]+)%s*=")
     if names then
-      -- AI HINTS: Extract first variable name
       local first_name = names:match("^([%w_]+)")
       if first_name then
         return { keyword = "local", capture_type = "variable", display = "local " .. first_name }
       end
     end
   end
-
-  -- AI HINTS: Module table assignments: `M.foo = function(...)` or `module.foo = function(...)`
   do
     local name = cleaned:match("^([%w_]+%.[%w_]+)%s*=%s*function%s*%(")
     if name then
       return { keyword = "function", capture_type = "function", display = "function " .. name }
     end
   end
-
-  -- AI HINTS: Table field function assignments: `foo = function(...)`
   do
     local name = cleaned:match("^([%w_]+)%s*=%s*function%s*%(")
     if name then
@@ -117,25 +84,12 @@ function M.parse_symbol(line_text)
 
   return nil
 end
-
--- AI HINTS: -Check if a line is a comment line in Lua.
--- AI HINTS: -@param trimmed string
--- AI HINTS: -@return boolean
 function M.is_comment_line(trimmed)
-  -- AI HINTS: Lua supports:
-  -- AI HINTS: - line comments: --
-  -- AI HINTS: - block comments: --[[ ... ]]
-  -- AI HINTS: - block comment continuation lines starting with --
   return trimmed:match("^%-%-") ~= nil
 end
-
--- AI HINTS: -Detect file header comments to reduce noise.
--- AI HINTS: -@param lines string[]
--- AI HINTS: -@param line_nr integer 1-indexed
--- AI HINTS: -@return boolean
 function M.is_file_header(lines, line_nr)
-  -- AI HINTS: File header blocks (license banners, generated comments) can dominate the minimap.
-  -- AI HINTS: We detect "a run of >=3 comment lines at the top of the file" and suppress them.
+  -- PURPOSE:
+  -- - Suppress banner-style comment blocks near the top of a file.
   if line_nr > 50 then
     return false
   end
@@ -163,15 +117,7 @@ function M.is_file_header(lines, line_nr)
 
   return comment_count >= 3 and line_nr <= header_end
 end
-
--- AI HINTS: -Extract comment text (remove markers, get first line only).
--- AI HINTS: -@param line string
--- AI HINTS: -@return string|nil, string|nil, boolean, string|nil
 function M.extract_comment(line)
-  -- AI HINTS: Extract a compact comment text suitable for minimap display:
-  -- AI HINTS: - remove comment markers (--, --[[, ]])
-  -- AI HINTS: - detect marker prefixes like TODO:/FIXME:/NOTE:
-  -- AI HINTS: - truncate to keep minimap lines compact
   local trimmed = vim.trim(line)
 
   local is_doc_comment = trimmed:match("^%-%-%-") ~= nil
@@ -215,17 +161,9 @@ function M.extract_comment(line)
 
   return text, marker, is_doc_comment, raw_text
 end
-
--- AI HINTS: -Render a comment entry for the minimap (no comment prefix).
--- AI HINTS: -@param line string
--- AI HINTS: -@param line_nr integer 1-indexed
--- AI HINTS: -@param all_lines string[]
--- AI HINTS: -@return {kind:"marker"|"comment", marker:string|nil, text:string}|nil
 function M.render_comment(line, line_nr, all_lines)
-  -- AI HINTS: Convert a source comment line into a minimap entry.
-  -- AI HINTS: Returns:
-  -- AI HINTS: - { kind="marker", marker="TODO", text="..." } for marker comments
-  -- AI HINTS: - { kind="comment", text="..." } for regular comments (non-header)
+  -- PURPOSE:
+  -- - Render marker comments and non-header comments only.
   local text, marker = M.extract_comment(line)
   if marker then
     return { kind = "marker", marker = marker, text = text or "" }

--- a/lua/xmap/lang/markdown.lua
+++ b/lua/xmap/lang/markdown.lua
@@ -1,12 +1,7 @@
--- AI HINTS: lua/xmap/lang/markdown.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Markdown language support for xmap.nvim
---
--- AI HINTS: Provides a minimal heading parser to build a TOC-style minimap for Markdown:
--- AI HINTS: - ATX headings: #, ##, ...
--- AI HINTS: - Setext headings: title line + === / --- underline (rendered on the first line)
--- AI HINTS: - Fenced code block starts (``` / ~~~)
--- AI HINTS: - Images: ![alt](path)
+-- PURPOSE:
+-- - Build TOC-style minimap entries for Markdown headings and rich blocks.
+-- CONSTRAINTS:
+-- - Never emit entries for lines inside fenced code blocks.
 
 local M = {}
 
@@ -46,15 +41,9 @@ local QUERY_VARIANTS = {
     (section) @class
   ]],
 }
-
--- AI HINTS: -Get Tree-sitter query candidates for Markdown headings.
--- AI HINTS: -@return string[]
 function M.get_queries()
   return QUERY_VARIANTS
 end
-
--- AI HINTS: -Get the primary Tree-sitter query string for Markdown.
--- AI HINTS: -@return string
 function M.get_query()
   return QUERY_VARIANTS[1]
 end
@@ -85,6 +74,8 @@ local function parse_fence_marker(text)
 end
 
 local function get_fence_info(all_lines)
+  -- PURPOSE:
+  -- - Cache code-fence open/inside state per line set.
   if type(all_lines) ~= "table" then
     return nil
   end
@@ -293,13 +284,9 @@ local function html_tag_symbol(line_text)
 
   return { keyword = "html", capture_type = "class", display = "<" .. tag .. ">", icon = HTML_ICON }
 end
-
--- AI HINTS: -Parse a Markdown line into a heading symbol entry.
--- AI HINTS: -@param line_text string
--- AI HINTS: -@param line_nr integer|nil
--- AI HINTS: -@param all_lines string[]|nil
--- AI HINTS: -@return {keyword:string, capture_type:string, display:string}|nil
 function M.parse_symbol(line_text, line_nr, all_lines)
+  -- DO:
+  -- - Prefer headings before inline artifacts such as links or images.
   if type(line_text) ~= "string" or line_text == "" then
     return nil
   end
@@ -321,8 +308,6 @@ function M.parse_symbol(line_text, line_nr, all_lines)
       end
     end
   end
-
-  -- AI HINTS: Avoid rendering the underline line for setext headings.
   if trimmed:match("^=+$") or trimmed:match("^-+$") then
     return nil
   end

--- a/lua/xmap/lang/swift.lua
+++ b/lua/xmap/lang/swift.lua
@@ -1,20 +1,5 @@
--- AI HINTS: lua/xmap/lang/swift.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Swift language support for xmap.nvim
---
--- AI HINTS: This provider implements Swift-specific logic required by the core minimap renderer:
--- AI HINTS: - A set of default declaration keywords to show in the minimap (func/struct/enum/...)
--- AI HINTS: - A Tree-sitter query (with fallbacks) to obtain structural node ranges for highlighting
--- AI HINTS: - A lightweight line-based parser (`parse_symbol`) that turns a source line into:
--- AI HINTS: { keyword = "...", capture_type = "...", display = "..." }
--- AI HINTS: where `capture_type` matches the generic icon/highlight maps in `treesitter.lua`.
--- AI HINTS: - Comment detection and rendering (including MARK/TODO/FIXME style markers)
---
--- AI HINTS: Why both Tree-sitter *and* a line parser?
--- AI HINTS: - Tree-sitter is optional and may not be installed.
--- AI HINTS: - Even when available, we only need it for structural highlighting ranges.
--- AI HINTS: - For the minimap list itself, a cheap line-based parser is often enough and avoids
--- AI HINTS: tight coupling to Tree-sitter node names across parser versions.
+-- PURPOSE:
+-- - Parse Swift declarations/comments with parser-version-safe query fallbacks.
 
 local M = {}
 
@@ -53,18 +38,13 @@ local function ltrim(text)
 end
 
 local function strip_swift_attributes(text)
-  -- AI HINTS: Swift declarations often start with attributes like:
-  -- AI HINTS: @MainActor
-  -- AI HINTS: @available(iOS 17, *)
-  -- AI HINTS: For minimap display we remove leading attributes to find the actual keyword.
+  -- PURPOSE:
+  -- - Ignore leading Swift attributes before keyword detection.
   local out = ltrim(text)
 
   while true do
     local before = out
-
-    -- AI HINTS: Attributes with args: @available(...)
     out = out:gsub("^@[%w_]+%b()%s*", "")
-    -- AI HINTS: Attributes without args: @MainActor
     out = out:gsub("^@[%w_]+%s*", "")
 
     out = ltrim(out)
@@ -77,9 +57,8 @@ local function strip_swift_attributes(text)
 end
 
 local function strip_swift_modifiers(text)
-  -- AI HINTS: Swift declarations also often contain modifiers:
-  -- AI HINTS: public/private/internal/open, final, static, override, ...
-  -- AI HINTS: We strip common ones so `parse_symbol` can match on `func`, `struct`, etc.
+  -- PURPOSE:
+  -- - Remove declaration modifiers that obscure the primary symbol keyword.
   local out = ltrim(text)
 
   local function strip(pattern)
@@ -93,12 +72,8 @@ local function strip_swift_modifiers(text)
 
   while true do
     local changed = false
-
-    -- AI HINTS: Access control (incl. private(set))
     changed = strip("^(public|private|fileprivate|internal|open)%s*%b()%s*") or changed
     changed = strip("^(public|private|fileprivate|internal|open)%s+") or changed
-
-    -- AI HINTS: Common modifiers
     changed = strip("^final%s+") or changed
     changed = strip("^static%s+") or changed
     changed = strip("^indirect%s+") or changed
@@ -111,8 +86,6 @@ local function strip_swift_modifiers(text)
     changed = strip("^convenience%s+") or changed
     changed = strip("^required%s+") or changed
     changed = strip("^dynamic%s+") or changed
-
-    -- AI HINTS: `class` can be a modifier for members (class func / class var), but also a type declaration.
     if out:match("^class%s+(func|var|let|subscript)%s") then
       changed = strip("^class%s+") or changed
     end
@@ -142,12 +115,8 @@ local function capture_value_name_after(keyword, text)
 end
 
 local QUERY_VARIANTS = {
-  -- AI HINTS: Tree-sitter node names for Swift have changed across parser versions.
-  -- AI HINTS: To avoid a hard failure on first run, we provide query candidates ordered
-  -- AI HINTS: from "newest known" to "most compatible". `treesitter.lua` tries these in
-  -- AI HINTS: order and caches the first one that parses successfully.
-
-  -- AI HINTS: Newer parsers
+  -- CONSTRAINTS:
+  -- - Keep fallback order aligned with known Swift parser node drift.
   [[
     (class_declaration) @class
     (struct_declaration) @class
@@ -164,8 +133,6 @@ local QUERY_VARIANTS = {
 
     (property_declaration) @variable
   ]],
-
-  -- AI HINTS: Some parsers use `deinit_declaration`
   [[
     (class_declaration) @class
     (struct_declaration) @class
@@ -182,8 +149,6 @@ local QUERY_VARIANTS = {
 
     (property_declaration) @variable
   ]],
-
-  -- AI HINTS: Without newer declarations (max compatibility)
   [[
     (class_declaration) @class
     (struct_declaration) @class
@@ -196,50 +161,29 @@ local QUERY_VARIANTS = {
 
     (property_declaration) @variable
   ]],
-
-  -- AI HINTS: Minimal (original)
   [[
     (class_declaration) @class
     (function_declaration) @function
     (init_declaration) @function
     (property_declaration) @variable
   ]],
-
-  -- AI HINTS: Minimal without properties (fallback)
   [[
     (class_declaration) @class
     (function_declaration) @function
     (init_declaration) @function
   ]],
 }
-
--- AI HINTS: -Get Tree-sitter query candidates for Swift (newest-first).
--- AI HINTS: -@return string[]
 function M.get_queries()
   return QUERY_VARIANTS
 end
-
--- AI HINTS: -Get the primary Tree-sitter query string for Swift.
--- AI HINTS: -@return string
 function M.get_query()
   return QUERY_VARIANTS[1]
 end
-
--- AI HINTS: -Parse a Swift declaration line into a symbol item.
--- AI HINTS: -@param line_text string
--- AI HINTS: -@return {keyword:string, capture_type:string, display:string}|nil
 function M.parse_symbol(line_text)
-  -- AI HINTS: Parsing strategy:
-  -- AI HINTS: 1) trim + strip attributes/modifiers
-  -- AI HINTS: 2) detect declaration keyword
-  -- AI HINTS: 3) capture a human-friendly name (when possible)
-  -- AI HINTS: 4) map to a generic capture_type used by `treesitter.get_icon_for_type`
   local cleaned = strip_swift_modifiers(strip_swift_attributes(line_text))
   if cleaned == "" then
     return nil
   end
-
-  -- AI HINTS: init/deinit (support init?, init!)
   local init_kind = cleaned:match("^init([?!]?)%s*%(")
   if init_kind ~= nil then
     local keyword = "init"
@@ -250,14 +194,10 @@ function M.parse_symbol(line_text)
   if cleaned:match("^deinit%s*[{%s]") then
     return { keyword = "deinit", capture_type = "function", display = "deinit" }
   end
-
-  -- AI HINTS: func
   local func_name = capture_func_name(cleaned)
   if func_name then
     return { keyword = "func", capture_type = "function", display = "func " .. func_name }
   end
-
-  -- AI HINTS: types
   local type_keywords = { "class", "struct", "enum", "protocol", "extension", "typealias", "actor" }
   for _, keyword in ipairs(type_keywords) do
     local name = capture_type_name_after(keyword, cleaned)
@@ -265,8 +205,6 @@ function M.parse_symbol(line_text)
       return { keyword = keyword, capture_type = "class", display = keyword .. " " .. name }
     end
   end
-
-  -- AI HINTS: properties
   local let_name = capture_value_name_after("let", cleaned)
   if let_name then
     return { keyword = "let", capture_type = "variable", display = "let " .. let_name }
@@ -280,8 +218,6 @@ function M.parse_symbol(line_text)
   if cleaned:match("^subscript%s*%(") then
     return { keyword = "subscript", capture_type = "function", display = "subscript" }
   end
-
-  -- AI HINTS: return statements (useful for quickly spotting exits/JSX returns)
   if cleaned == "return" or cleaned:match("^return%f[%W]") then
     local rest = vim.trim((cleaned:gsub("^return", "", 1)))
     rest = vim.trim((rest:gsub(";+%s*$", "")))
@@ -294,26 +230,12 @@ function M.parse_symbol(line_text)
 
   return nil
 end
-
--- AI HINTS: -Check if a line is a comment line in Swift.
--- AI HINTS: -@param trimmed string
--- AI HINTS: -@return boolean
 function M.is_comment_line(trimmed)
-  -- AI HINTS: Swift supports:
-  -- AI HINTS: - line comments: //
-  -- AI HINTS: - doc comments:  ///
-  -- AI HINTS: - block comments: /* ... */
-  -- AI HINTS: plus block-comment "continuation" lines that often start with `*`.
   return trimmed:match("^//") or trimmed:match("^/%*") or trimmed:match("^%*")
 end
-
--- AI HINTS: -Detect file header comments to reduce noise.
--- AI HINTS: -@param lines string[]
--- AI HINTS: -@param line_nr integer 1-indexed
--- AI HINTS: -@return boolean
 function M.is_file_header(lines, line_nr)
-  -- AI HINTS: File header blocks (license banners, generated comments) can dominate the minimap.
-  -- AI HINTS: We detect "a run of >=3 comment lines at the top of the file" and suppress them.
+  -- PURPOSE:
+  -- - Suppress large header comment blocks near file start.
   if line_nr > 50 then
     return false
   end
@@ -341,15 +263,7 @@ function M.is_file_header(lines, line_nr)
 
   return comment_count >= 3 and line_nr <= header_end
 end
-
--- AI HINTS: -Extract comment text (remove markers, get first line only).
--- AI HINTS: -@param line string
--- AI HINTS: -@return string|nil, string|nil, boolean, string|nil
 function M.extract_comment(line)
-  -- AI HINTS: Extract a compact comment text suitable for minimap display:
-  -- AI HINTS: - remove comment markers (//, ///, /*, *)
-  -- AI HINTS: - detect marker prefixes like MARK:/TODO:/FIXME:
-  -- AI HINTS: - truncate to keep minimap lines compact
   local trimmed = vim.trim(line)
 
   local is_doc_comment = trimmed:match("^///") or trimmed:match("^/%*%*")
@@ -395,17 +309,9 @@ function M.extract_comment(line)
 
   return text, marker, is_doc_comment, raw_text
 end
-
--- AI HINTS: -Render a comment entry for the minimap (no comment prefix).
--- AI HINTS: -@param line string
--- AI HINTS: -@param line_nr integer 1-indexed
--- AI HINTS: -@param all_lines string[]
--- AI HINTS: -@return {kind:"marker"|"comment", marker:string|nil, text:string}|nil
 function M.render_comment(line, line_nr, all_lines)
-  -- AI HINTS: Convert a source comment line into a minimap entry.
-  -- AI HINTS: Returns:
-  -- AI HINTS: - { kind="marker", marker="TODO", text="..." } for marker comments
-  -- AI HINTS: - { kind="comment", text="..." } for regular comments (non-header)
+  -- PURPOSE:
+  -- - Render marker comments and regular comments outside file headers.
   local text, marker = M.extract_comment(line)
   if marker then
     return { kind = "marker", marker = marker, text = text or "" }

--- a/lua/xmap/lang/typescript.lua
+++ b/lua/xmap/lang/typescript.lua
@@ -1,10 +1,7 @@
--- AI HINTS: lua/xmap/lang/typescript.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: TypeScript language support for xmap.nvim
---
--- AI HINTS: This provider implements a lightweight, line-based parser for common TypeScript
--- AI HINTS: declarations (functions/classes/types/etc.) and a Tree-sitter query for structural
--- AI HINTS: scope highlighting.
+-- PURPOSE:
+-- - Parse TypeScript/TSX declarations and comment forms for minimap rendering.
+-- CONSTRAINTS:
+-- - Treat JSX block comments as comment lines.
 
 local M = {}
 
@@ -57,10 +54,8 @@ local RESERVED = {
 }
 
 local function strip_ts_modifiers(text)
-  -- AI HINTS: Strip common modifiers so we can match declarations consistently.
-  -- AI HINTS: Examples:
-  -- AI HINTS: export default class Foo
-  -- AI HINTS: public async render(): JSX.Element {
+  -- PURPOSE:
+  -- - Remove declaration modifiers before pattern matching.
   local out = ltrim(text)
 
   local function strip(pattern)
@@ -95,17 +90,14 @@ local function strip_ts_modifiers(text)
 end
 
 local function looks_like_arrow_function(rhs)
+  -- PURPOSE:
+  -- - Distinguish function-valued assignments from plain variables.
   local text = ltrim(rhs or "")
   text = text:gsub("^async%s+", "")
 
   if text:match("^function") then
     return true
   end
-
-  -- AI HINTS: Arrow functions:
-  -- AI HINTS: (a, b) => ...
-  -- AI HINTS: a => ...
-  -- AI HINTS: <T>(a: T) => ...
   if text:match("^%b()%s*=>") then
     return true
   end
@@ -123,7 +115,8 @@ local function looks_like_arrow_function(rhs)
 end
 
 local QUERY_VARIANTS = {
-  -- AI HINTS: TypeScript / TSX
+  -- CONSTRAINTS:
+  -- - Keep a minimal fallback for parser/query compatibility.
   [[
     (class_declaration) @class
     (interface_declaration) @class
@@ -133,41 +126,25 @@ local QUERY_VARIANTS = {
     (function_declaration) @function
     (method_definition) @method
   ]],
-
-  -- AI HINTS: Minimal fallback
   [[
     (class_declaration) @class
     (function_declaration) @function
   ]],
 }
-
--- AI HINTS: -Get Tree-sitter query candidates for TypeScript (newest-first).
--- AI HINTS: -@return string[]
 function M.get_queries()
   return QUERY_VARIANTS
 end
-
--- AI HINTS: -Get the primary Tree-sitter query string for TypeScript.
--- AI HINTS: -@return string
 function M.get_query()
   return QUERY_VARIANTS[1]
 end
-
--- AI HINTS: -Parse a TypeScript declaration line into a symbol item.
--- AI HINTS: -@param line_text string
--- AI HINTS: -@return {keyword:string, capture_type:string, display:string}|nil
 function M.parse_symbol(line_text)
   local cleaned = strip_ts_modifiers(line_text or "")
   if cleaned == "" then
     return nil
   end
-
-  -- AI HINTS: Ignore decorator lines (Angular/TS ecosystems)
   if cleaned:match("^@") then
     return nil
   end
-
-  -- AI HINTS: return statements
   if cleaned == "return" or cleaned:match("^return%f[%W]") then
     local rest = vim.trim((cleaned:gsub("^return", "", 1)))
     rest = vim.trim((rest:gsub(";+%s*$", "")))
@@ -177,8 +154,6 @@ function M.parse_symbol(line_text)
     end
     return { keyword = "return", capture_type = "function", display = display }
   end
-
-  -- AI HINTS: class / interface / type / enum / namespace / module
   do
     local name = cleaned:match("^class%s+([%w_$]+)")
     if name then
@@ -213,16 +188,12 @@ function M.parse_symbol(line_text)
       return { keyword = keyword, capture_type = "class", display = keyword .. " " .. name }
     end
   end
-
-  -- AI HINTS: function declarations
   do
     local name = cleaned:match("^function%s*%*?%s+([%w_$]+)")
     if name then
       return { keyword = "function", capture_type = "function", display = "function " .. name }
     end
   end
-
-  -- AI HINTS: const/let/var declarations (treat arrow/function assignments as "function")
   do
     local kw, name = cleaned:match("^(%a+)%s+([%w_$]+)")
     if (kw == "const" or kw == "let" or kw == "var") and name then
@@ -237,11 +208,9 @@ function M.parse_symbol(line_text)
       return { keyword = kw, capture_type = "variable", display = kw .. " " .. name }
     end
   end
-
-  -- AI HINTS: Member methods: `foo() {` / `foo(): T {` / `get foo() {`
   do
     local member = strip_ts_modifiers(cleaned)
-    member = member:gsub("^%*%s*", "") -- AI HINTS: generator marker
+    member = member:gsub("^%*%s*", "")
 
     local accessor, acc_name = member:match("^(get)%s+([%w_$]+)%s*<[^>]*>%s*%b()%s*[:{]")
     if not accessor then
@@ -269,8 +238,6 @@ function M.parse_symbol(line_text)
       return { keyword = "method", capture_type = "method", display = "method " .. meth_name }
     end
   end
-
-  -- AI HINTS: Member arrow/function properties: `foo = (...) =>` / `foo: T = (...) =>`
   do
     local member = strip_ts_modifiers(cleaned)
     local name, rhs = member:match("^([%w_$]+)%s*=%s*(.+)$")
@@ -281,8 +248,6 @@ function M.parse_symbol(line_text)
       return { keyword = "method", capture_type = "method", display = "method " .. name }
     end
   end
-
-  -- AI HINTS: Property signatures (interfaces/types/classes): `foo?: T` / `foo!: T`
   do
     local member = strip_ts_modifiers(cleaned)
     local name = member:match("^([%w_$]+)%s*[%?!%!]*%s*:%s+")
@@ -293,16 +258,9 @@ function M.parse_symbol(line_text)
 
   return nil
 end
-
--- AI HINTS: -Check if a line is a comment line in TypeScript.
--- AI HINTS: -@param trimmed string
--- AI HINTS: -@return boolean
 function M.is_comment_line(trimmed)
-  -- AI HINTS: TS/TSX supports `//` line comments and `/* ... */` block comments.
-  -- AI HINTS: In TSX (typescriptreact), JSX comments look like: `{/* comment */}`.
-  --
-  -- AI HINTS: Note: avoid treating generator methods (`*foo() {}`) as comments by requiring
-  -- AI HINTS: whitespace after `*` for block-comment continuation lines.
+  -- PURPOSE:
+  -- - Detect TS, block, continuation, and JSX comment lines.
   return trimmed:match("^//")
     or trimmed:match("^/%*")
     or trimmed:match("^%*/")
@@ -310,11 +268,6 @@ function M.is_comment_line(trimmed)
     or trimmed == "*"
     or trimmed:match("^%{%s*/%*")
 end
-
--- AI HINTS: -Detect file header comments to reduce noise.
--- AI HINTS: -@param lines string[]
--- AI HINTS: -@param line_nr integer 1-indexed
--- AI HINTS: -@return boolean
 function M.is_file_header(lines, line_nr)
   if line_nr > 50 then
     return false
@@ -357,7 +310,6 @@ local function is_jsx_block_comment_line(trimmed)
 end
 
 local function find_enclosing_block_comment_start(all_lines, line_nr)
-  -- AI HINTS: Walk backwards and find the nearest `/*` start without crossing a `*/` end.
   for i = line_nr - 1, math.max(1, line_nr - 200), -1 do
     local trimmed = vim.trim(all_lines[i] or "")
     if is_block_comment_end(trimmed) then
@@ -371,13 +323,10 @@ local function find_enclosing_block_comment_start(all_lines, line_nr)
 end
 
 local function find_first_block_comment_entry(all_lines, start_line_nr)
-  -- AI HINTS: Return the first meaningful comment entry within a /* ... */ block:
-  -- AI HINTS: - first non-@tag text line (preferred)
-  -- AI HINTS: - otherwise the first MARK/TODO/etc marker line
-  -- AI HINTS: The returned `line_nr` is where the entry should be rendered.
+  -- ALGORITHM:
+  -- - Prefer the first non-tag text line inside the block.
+  -- - Fall back to the first marker line when the block is marker-only.
   local marker_line_nr, marker_name, marker_text = nil, nil, nil
-
-  -- AI HINTS: Opening line can carry text: `/** Summary` or `/* Summary */`
   do
     local text, marker = M.extract_comment(all_lines[start_line_nr] or "")
     if marker then
@@ -409,21 +358,13 @@ local function find_first_block_comment_entry(all_lines, start_line_nr)
 
   return nil
 end
-
--- AI HINTS: -Extract comment text (remove markers, get first line only).
--- AI HINTS: -@param line string
--- AI HINTS: -@return string|nil, string|nil, boolean, string|nil
 function M.extract_comment(line)
   local trimmed = vim.trim(line)
 
   local is_doc_comment = trimmed:match("^///") or trimmed:match("^/%*%*") or trimmed:match("^%{%s*/%*%*")
-
-  -- AI HINTS: Skip pure opening/closing markers for block/JSX comments.
   if trimmed == "/*" or trimmed == "/**" or trimmed == "*/" or trimmed:match("^%*/%s*%}$") then
     return nil, nil, is_doc_comment
   end
-
-  -- AI HINTS: JSX comment: `{/* ... */}` (TSX)
   do
     local jsx_inner = trimmed:match("^%{%s*/%*(.-)%*/%s*%}$")
     if jsx_inner ~= nil then
@@ -504,15 +445,10 @@ function M.extract_comment(line)
 
   return text, marker, is_doc_comment, raw_text
 end
-
--- AI HINTS: -Render a comment entry for the minimap (no comment prefix).
--- AI HINTS: -@param line string
--- AI HINTS: -@param line_nr integer 1-indexed
--- AI HINTS: -@param all_lines string[]
--- AI HINTS: -@return {kind:"marker"|"comment", marker:string|nil, text:string}|nil
 function M.render_comment(line, line_nr, all_lines)
+  -- PURPOSE:
+  -- - Collapse block comments to one rendered entry and skip closing lines.
   local trimmed = vim.trim(line)
-  -- AI HINTS: TSX JSX comment: `{/* ... */}`.
   if is_jsx_block_comment_line(trimmed) then
     local text, marker = M.extract_comment(line)
     if marker then
@@ -523,13 +459,9 @@ function M.render_comment(line, line_nr, all_lines)
     end
     return nil
   end
-
-  -- AI HINTS: Never render the closing line of a block comment.
   if is_block_comment_end(trimmed) then
     return nil
   end
-
-  -- AI HINTS: Block comment opening line: render only if it contains meaningful text.
   if is_block_comment_start(trimmed) then
     local text, marker = M.extract_comment(line)
     if marker then
@@ -540,8 +472,6 @@ function M.render_comment(line, line_nr, all_lines)
     end
     return nil
   end
-
-  -- AI HINTS: Block comment continuation (`* ...`): render only the first meaningful text line.
   if trimmed:match("^%*") then
     local start_line_nr = find_enclosing_block_comment_start(all_lines, line_nr)
     if not start_line_nr then

--- a/lua/xmap/lang/typescriptreact.lua
+++ b/lua/xmap/lang/typescriptreact.lua
@@ -1,16 +1,11 @@
--- AI HINTS: lua/xmap/lang/typescriptreact.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: TypeScript React (TSX) language support for xmap.nvim
---
--- AI HINTS: Neovim uses `typescriptreact` as the filetype for `.tsx` files. Most of the parsing
--- AI HINTS: rules are shared with TypeScript, but TSX benefits from React-specific heuristics
--- AI HINTS: (hook calls + common component wrappers) for a more useful minimap outline.
+-- PURPOSE:
+-- - Extend the TypeScript provider with React hook/component heuristics.
+-- CONSTRAINTS:
+-- - Defer to the base TypeScript provider when React-specific patterns do not match.
 
 local ts = require("xmap.lang.typescript")
 
 local M = {}
-
--- AI HINTS: Copy base TypeScript provider surface.
 for k, v in pairs(ts) do
   M[k] = v
 end
@@ -35,7 +30,6 @@ local function ltrim(text)
 end
 
 local function strip_ts_modifiers(text)
-  -- AI HINTS: Keep consistent with the TypeScript provider: strip leading modifiers for easier matching.
   local out = ltrim(text or "")
 
   local function strip(pattern)
@@ -77,14 +71,10 @@ local function parse_hook_call(text)
   local t = ltrim(text or "")
 
   local hook_name, args
-
-  -- AI HINTS: Generic call: useState<T>(...)
   hook_name, _, args = t:match("^React%.(use%u[%w_$]*)%s*(%b<>)%s*%((.*)$")
   if not hook_name then
     hook_name, _, args = t:match("^(use%u[%w_$]*)%s*(%b<>)%s*%((.*)$")
   end
-
-  -- AI HINTS: Non-generic call: useEffect(...)
   if not hook_name then
     hook_name, args = t:match("^React%.(use%u[%w_$]*)%s*%((.*)$")
   end
@@ -130,11 +120,6 @@ local function looks_like_arrow_function(rhs)
   if text:match("^function") then
     return true
   end
-
-  -- AI HINTS: Arrow functions:
-  -- AI HINTS: (a, b) => ...
-  -- AI HINTS: a => ...
-  -- AI HINTS: <T>(a: T) => ...
   if text:match("^%b()%s*=>") then
     return true
   end
@@ -177,18 +162,14 @@ local function is_wrapped_react_component(rhs)
 end
 
 local function parse_react_hook_symbol(cleaned)
-  -- AI HINTS: Direct hook call: `useEffect(...)` / `React.useEffect(...)`
+  -- PURPOSE:
+  -- - Surface hook calls and hook assignments as dedicated minimap entries.
   do
     local hook_name, first_arg = parse_hook_call(cleaned)
     if hook_name then
       return hook_symbol(hook_name, first_arg)
     end
   end
-
-  -- AI HINTS: Hook call assigned to a const/let/var:
-  -- AI HINTS: const value = useMemo(...)
-  -- AI HINTS: const [value, setValue] = useState(...)
-  -- AI HINTS: const { value } = useContext(...)
   do
     local kw, lhs, rhs = cleaned:match("^(%a+)%s*(%b[])%s*=%s*(.+)$")
     if (kw == "const" or kw == "let" or kw == "var") and lhs and rhs then
@@ -223,36 +204,24 @@ local function parse_react_hook_symbol(cleaned)
 
   return nil
 end
-
--- AI HINTS: -Parse TSX/React symbols + hook calls.
--- AI HINTS: -@param line_text string
--- AI HINTS: -@return {keyword:string, capture_type:string, display:string}|nil
 function M.parse_symbol(line_text)
   local cleaned = strip_ts_modifiers(line_text or "")
   if cleaned == "" then
     return nil
   end
-
-  -- AI HINTS: Ignore decorator lines (Angular/TS ecosystems).
   if cleaned:match("^@") then
     return nil
   end
-
-  -- AI HINTS: React hooks: show `hook useX` entries (useful inside components).
   local hook = parse_react_hook_symbol(cleaned)
   if hook then
     return hook
   end
-
-  -- AI HINTS: React component wrappers: `const Foo = memo((...) => ...)` should show as a function entry.
   do
     local kw, name, rhs = cleaned:match("^(%a+)%s+([%w_$]+)%s*.-=%s*(.+)$")
     if (kw == "const" or kw == "let" or kw == "var") and name and rhs and is_pascal_case(name) and is_wrapped_react_component(rhs) then
       return function_symbol(name)
     end
   end
-
-  -- AI HINTS: Default TypeScript parsing.
   local symbol = ts.parse_symbol(line_text)
   if not symbol then
     return nil
@@ -260,9 +229,6 @@ function M.parse_symbol(line_text)
 
   return symbol
 end
-
--- AI HINTS: TSX tends to use const-assigned arrow functions for components. Improve Tree-sitter highlighting
--- AI HINTS: by capturing those declarations as @function when possible (fallbacks included).
 local QUERY_VARIANTS = {
   [[
     (class_declaration) @class
@@ -281,6 +247,8 @@ local QUERY_VARIANTS = {
 }
 
 function M.get_queries()
+  -- DO:
+  -- - Prepend TSX-specific captures before the base TypeScript fallbacks.
   local base = {}
   if type(ts.get_queries) == "function" then
     local ok, queries = pcall(ts.get_queries)

--- a/lua/xmap/minimap.lua
+++ b/lua/xmap/minimap.lua
@@ -1,23 +1,8 @@
--- AI HINTS: lua/xmap/minimap.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Minimap window and rendering logic for xmap.nvim
---
--- AI HINTS: This is the core runtime module of the plugin. It owns:
--- AI HINTS: - the minimap scratch buffer + split window
--- AI HINTS: - render/update loops (throttled, cursor-only updates)
--- AI HINTS: - mapping between minimap lines and source buffer lines
--- AI HINTS: - applying multiple highlight layers (viewport, cursor, prefix, structure)
---
--- AI HINTS: Important separation of concerns:
--- AI HINTS: - Language-specific parsing lives in provider modules (`lua/xmap/lang/<filetype>.lua`)
--- AI HINTS: - Keyword filtering rules live in `symbols.lua`
--- AI HINTS: - Tree-sitter queries + node extraction live in `treesitter.lua`
--- AI HINTS: - Highlight group definitions/overrides live in `highlight.lua`
---
--- AI HINTS: The minimap is a *derived view*: it does not necessarily include every source line.
--- AI HINTS: When a line *is* rendered, we record a mapping:
--- AI HINTS: minimap_line (1-indexed) -> source_line (1-indexed)
--- AI HINTS: This mapping is used by navigation/jump logic.
+-- PURPOSE:
+-- - Own minimap buffer/window lifecycle, rendering, and follow-target state.
+-- CONSTRAINTS:
+-- - Keep parsing/provider logic outside this module.
+-- - Treat the minimap as a derived view backed by `line_mapping`.
 
 local config = require("xmap.config")
 local highlight = require("xmap.highlight")
@@ -28,12 +13,11 @@ local navigation = require("xmap.navigation")
 
 local M = {}
 
--- AI HINTS: The relative distance column is capped to keep layout stable.
+-- PURPOSE:
+-- - Cap prefix width so relative numbers never widen the minimap layout.
 local MAX_RELATIVE_DISTANCE = 999
 
 local function pad_right(text, width)
-	-- AI HINTS: Pad using display width so multi-byte symbols (e.g. "↓", "·") don't produce
-	-- AI HINTS: unexpected extra spaces. This keeps the prefix visually aligned.
 	text = text or ""
 	local len = vim.api.nvim_strwidth(text)
 	if len >= width then
@@ -43,8 +27,6 @@ local function pad_right(text, width)
 end
 
 local function build_relative_prefix_settings(opts)
-	-- AI HINTS: Normalize the `render.relative_prefix` config into a compact table the render loop
-	-- AI HINTS: can reuse. This is called once per full render and cached in `M.state`.
 	local render_opts = (opts and opts.render) or {}
 	local rp = type(render_opts.relative_prefix) == "table" and render_opts.relative_prefix or {}
 
@@ -79,9 +61,6 @@ local function build_relative_prefix_settings(opts)
 end
 
 local function format_relative_prefix(source_line, current_line, settings)
-	-- AI HINTS: Produce the prefix shown at the start of each minimap line, e.g.:
-	-- AI HINTS: " 12 ↓ " (distance + direction + trailing separator)
-	-- AI HINTS: The prefix is re-rendered frequently (cursor moves), so keep it cheap.
 	local delta = source_line - current_line
 	local direction = "current"
 	if delta < 0 then
@@ -104,38 +83,29 @@ local function format_relative_prefix(source_line, current_line, settings)
 
 	return direction, prefix
 end
-
--- AI HINTS: Minimap state
 M.state = {
-	-- AI HINTS: Window/buffer handles
-	bufnr = nil, -- AI HINTS: Minimap scratch buffer (render target)
-	winid = nil, -- AI HINTS: Minimap split window
-	main_bufnr = nil, -- AI HINTS: Source buffer currently being mapped
-	main_winid = nil, -- AI HINTS: Window showing the source buffer
-
-	-- AI HINTS: Lifecycle flags/timers
+	bufnr = nil,
+	winid = nil,
+	main_bufnr = nil,
+	main_winid = nil,
 	is_open = false,
-	last_update = 0, -- AI HINTS: Last full render timestamp (ms)
-	update_timer = nil, -- AI HINTS: Throttle timer for full renders
-	last_relative_update = 0, -- AI HINTS: Last prefix-only update timestamp (ms)
-	relative_timer = nil, -- AI HINTS: Throttle timer for prefix-only updates
-
-	-- AI HINTS: Render caches
-	line_mapping = {}, -- AI HINTS: minimap_line -> source_line mapping (both 1-indexed)
-	content_by_line = {}, -- AI HINTS: minimap_line -> rendered content (without prefix)
-	entry_kinds = {}, -- AI HINTS: minimap_line -> entry kind ("symbol", "comment", etc.)
-	entry_symbols = {}, -- AI HINTS: minimap_line -> parsed symbol metadata (if any)
-	structural_nodes = {}, -- AI HINTS: Cached Tree-sitter nodes for structural highlighting
-	relative_prefix_settings = nil, -- AI HINTS: Cached prefix config (widths, symbols, separators)
-
-	-- AI HINTS: Navigation UX helpers
-	navigation_anchor_line = nil, -- AI HINTS: Base line for relative distances while minimap is focused
-	follow_scheduled = false, -- AI HINTS: Coalesce follow-current-buffer updates
+	last_update = 0,
+	update_timer = nil,
+	last_relative_update = 0,
+	relative_timer = nil,
+	line_mapping = {},
+	content_by_line = {},
+	entry_kinds = {},
+	entry_symbols = {},
+	structural_nodes = {},
+	relative_prefix_settings = nil,
+	navigation_anchor_line = nil,
+	follow_scheduled = false,
 }
 
 local function resolve_main_winid()
-	-- AI HINTS: Recover the current window showing the attached main buffer.
-	-- AI HINTS: This keeps cursor/relative-position updates working after window layout changes.
+	-- PURPOSE:
+	-- - Recover the active window that still shows `main_bufnr`.
 	if not (M.state.main_bufnr and vim.api.nvim_buf_is_valid(M.state.main_bufnr)) then
 		return nil
 	end
@@ -161,9 +131,8 @@ local function resolve_main_winid()
 end
 
 local function get_relative_base_line(main_winid)
-	-- AI HINTS: While the minimap is focused we can optionally "anchor" the base line so the
-	-- AI HINTS: relative numbers don't constantly shift under the cursor during navigation.
-	-- AI HINTS: This makes the minimap feel more like a stable list.
+	-- PURPOSE:
+	-- - Freeze the relative-number anchor while the minimap is focused.
 	local resolved_main_winid = main_winid
 	if
 		not (
@@ -184,66 +153,31 @@ local function get_relative_base_line(main_winid)
 	end
 	return M.state.navigation_anchor_line
 end
-
--- AI HINTS: Namespace for highlights
--- AI HINTS: We use separate namespaces so different highlight layers can be cleared independently:
--- AI HINTS: - viewport: the portion visible in the main window
--- AI HINTS: - cursor: the minimap cursor/selection row
--- AI HINTS: - syntax: relative prefix + comment/keyword highlights
--- AI HINTS: - structure: Tree-sitter structural highlights (function/class ranges)
 M.ns_viewport = highlight.create_namespace("viewport")
 M.ns_cursor = highlight.create_namespace("cursor")
-M.ns_syntax = highlight.create_namespace("syntax") -- AI HINTS: arrows, numbers, comments
-M.ns_structure = highlight.create_namespace("structure") -- AI HINTS: Tree-sitter structural scopes
-
--- AI HINTS: Create minimap buffer
--- OUTPUT: number: Buffer number
+M.ns_syntax = highlight.create_namespace("syntax")
+M.ns_structure = highlight.create_namespace("structure")
 function M.create_buffer()
 	local buf_name = "xmap://minimap"
-
-	-- AI HINTS: Check if a buffer with this name already exists
-	-- AI HINTS: (this can happen during hot-reload or when the plugin didn't clean up properly).
 	local existing_buf = vim.fn.bufnr(buf_name)
 	if existing_buf ~= -1 and vim.api.nvim_buf_is_valid(existing_buf) then
-		-- AI HINTS: Delete the existing buffer
 		pcall(vim.api.nvim_buf_delete, existing_buf, { force = true })
 	end
 
-	local buf = vim.api.nvim_create_buf(false, true) -- AI HINTS: No file, scratch buffer
-
-	-- AI HINTS: Set buffer options
-	-- AI HINTS: The minimap buffer is:
-	-- AI HINTS: - unlisted (doesn't show up in :ls)
-	-- AI HINTS: - wiped when hidden (so it won't linger)
-	-- AI HINTS: - marked as "xmap" filetype (useful for custom highlights if desired)
+	local buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
 	vim.api.nvim_buf_set_option(buf, "swapfile", false)
 	vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
 	vim.api.nvim_buf_set_option(buf, "buflisted", false)
 	vim.api.nvim_buf_set_option(buf, "filetype", "xmap")
 	vim.api.nvim_buf_set_name(buf, buf_name)
-
-	-- AI HINTS: We toggle `modifiable` only while writing new lines during updates.
-	-- AI HINTS: Keep it `true` here so the first render can populate content.
 	vim.api.nvim_buf_set_option(buf, "modifiable", true)
 
 	return buf
 end
-
--- AI HINTS: Create minimap window
--- INPUT: bufnr number: Buffer to display in minimap
--- OUTPUT: number: Window ID
 function M.create_window(bufnr)
 	local opts = config.get()
-
-	-- AI HINTS: Create split window instead of floating for better integration.
-	-- AI HINTS: We keep the minimap as a standard split so it plays well with window navigation
-	-- AI HINTS: and doesn't require floating-window sizing logic.
 	local current_win = vim.api.nvim_get_current_win()
-
-	-- AI HINTS: Create vertical split
-	-- AI HINTS: Use `botright`/`topleft` so the minimap stays pinned to the outer edge of the
-	-- AI HINTS: tabpage layout (instead of splitting relative to the currently-focused window).
 	if opts.side == "left" then
 		vim.cmd("topleft vsplit")
 	else
@@ -251,16 +185,8 @@ function M.create_window(bufnr)
 	end
 
 	local win = vim.api.nvim_get_current_win()
-
-	-- AI HINTS: Set the buffer in the new window
 	vim.api.nvim_win_set_buf(win, bufnr)
-
-	-- AI HINTS: Set window width
 	vim.api.nvim_win_set_width(win, opts.width)
-
-	-- AI HINTS: Set window options
-	-- AI HINTS: The minimap window is a "view only" panel: no line numbers, no wraps, no signs,
-	-- AI HINTS: and a fixed width so the layout stays stable while editing.
 	vim.api.nvim_win_set_option(win, "number", false)
 	vim.api.nvim_win_set_option(win, "relativenumber", false)
 	vim.api.nvim_win_set_option(win, "cursorline", false)
@@ -268,14 +194,12 @@ function M.create_window(bufnr)
 	vim.api.nvim_win_set_option(win, "signcolumn", "no")
 	vim.api.nvim_win_set_option(win, "foldcolumn", "0")
 	vim.api.nvim_win_set_option(win, "winfixwidth", true)
-	vim.api.nvim_win_set_option(win, "fillchars", "eob: ") -- AI HINTS: Remove ~ for empty lines
+	vim.api.nvim_win_set_option(win, "fillchars", "eob: ")
 	vim.api.nvim_win_set_option(
 		win,
 		"winhighlight",
 		"Normal:XmapBackground,NormalNC:XmapBackground,EndOfBuffer:XmapBackground,SignColumn:XmapBackground,FoldColumn:XmapBackground"
 	)
-
-	-- AI HINTS: Return to original window
 	vim.api.nvim_set_current_win(current_win)
 
 	return win
@@ -290,23 +214,9 @@ local MARKDOWN_HEADING_HIGHLIGHTS = {
 	H5 = "XmapMarkdownH5",
 	H6 = "XmapMarkdownH6",
 }
-
--- AI HINTS: Render a single line for the minimap (language-driven structural overview)
--- INPUT: line string: Original line from main buffer
--- INPUT: line_nr number: Line number (1-indexed)
--- INPUT: current_line number: Current base line in main buffer (1-indexed)
--- INPUT: all_lines table: All buffer lines (for context)
--- INPUT: ctx table: Rendering context (provider, enabled keywords, etc.)
--- OUTPUT: string|nil, string|nil, string|nil: Rendered line, content, and entry kind (or nil)
 function M.render_line(line, line_nr, current_line, all_lines, ctx)
-	-- AI HINTS: The minimap does not render every source line. A provider decides:
-	-- AI HINTS: - which comment lines are worth showing (including MARK/TODO markers)
-	-- AI HINTS: - which declarations count as a "symbol" entry (func/struct/enum/etc.)
-	--
-	-- AI HINTS: We return both:
-	-- AI HINTS: 1) the full rendered line (prefix + content)
-	-- AI HINTS: 2) the content portion only (used for fast prefix-only updates)
-	-- AI HINTS: 3) the entry kind (used for comment/symbol highlighting decisions)
+	-- PURPOSE:
+	-- - Render one source line into a minimap entry or skip it.
 	if not ctx or not ctx.provider then
 		return nil
 	end
@@ -317,7 +227,6 @@ function M.render_line(line, line_nr, current_line, all_lines, ctx)
 	local entry_symbol = nil
 
 	if trimmed ~= "" and ctx.provider.is_comment_line and ctx.provider.is_comment_line(trimmed) then
-		-- AI HINTS: Comments/markers are rendered as separate minimap entries with the comment icon.
 		if type(ctx.provider.render_comment) ~= "function" then
 			return nil
 		end
@@ -355,13 +264,10 @@ function M.render_line(line, line_nr, current_line, all_lines, ctx)
 			end
 		end
 	elseif type(ctx.provider.parse_symbol) == "function" then
-		-- AI HINTS: Symbols are identified by a cheap line parser that extracts the declaration kind and name.
 		local symbol = ctx.provider.parse_symbol(trimmed, line_nr, all_lines)
 		if not symbol then
 			return nil
 		end
-
-		-- AI HINTS: Apply per-language keyword filtering (configured via `opts.symbols.<filetype>`).
 		if not (ctx.enabled_symbol_keywords and ctx.enabled_symbol_keywords[symbol.keyword]) then
 			return nil
 		end
@@ -391,13 +297,6 @@ function M.render_line(line, line_nr, current_line, all_lines, ctx)
 	local _, prefix = format_relative_prefix(line_nr, current_line, ctx.prefix_settings)
 	return prefix .. content, content, entry_kind, entry_symbol
 end
-
--- AI HINTS: Render entire buffer content for minimap
--- INPUT: main_bufnr number: Main buffer to render
--- INPUT: main_winid number: Main window (to get current line)
--- INPUT: current_line_override number|nil: Optional base line override
--- OUTPUT: string[], integer[], table, table, string[], string[]:
--- AI HINTS: rendered_lines, line_mapping, structural_nodes, prefix_settings, content_by_line, entry_kinds, entry_symbols
 function M.render_buffer(main_bufnr, main_winid, current_line_override)
 	if not vim.api.nvim_buf_is_valid(main_bufnr) then
 		return {}, {}, {}, {}, {}, {}
@@ -405,8 +304,6 @@ function M.render_buffer(main_bufnr, main_winid, current_line_override)
 
 	local opts = config.get()
 	local prefix_settings = build_relative_prefix_settings(opts)
-
-	-- AI HINTS: Get current line in main buffer
 	local current_line = current_line_override or navigation.get_main_cursor_line(main_winid)
 
 	local lines = vim.api.nvim_buf_get_lines(main_bufnr, 0, -1, false)
@@ -414,24 +311,16 @@ function M.render_buffer(main_bufnr, main_winid, current_line_override)
 	local content_by_line = {}
 	local entry_kinds = {}
 	local entry_symbols = {}
-	local line_mapping = {} -- AI HINTS: Maps minimap line number to source line number
+	local line_mapping = {}
 	local structural_nodes = {}
-
-	-- AI HINTS: Identify which language provider to use (based on `vim.bo.filetype`).
-	-- AI HINTS: If no provider exists, xmap does not render anything for this buffer.
 	local filetype = vim.api.nvim_buf_get_option(main_bufnr, "filetype")
 	local provider = lang.get(filetype)
 	if not provider then
 		return {}, {}, {}, {}, {}, {}, {}
 	end
-
-	-- AI HINTS: Tree-sitter is optional and used only for structural highlighting.
-	-- AI HINTS: The minimap list itself is rendered using the provider's line parser.
 	if config.is_treesitter_enabled(filetype) then
 		structural_nodes = treesitter.get_structural_nodes(main_bufnr, filetype)
 	end
-
-	-- AI HINTS: Build the enabled keyword set once and reuse it for every line.
 	local enabled_symbol_keywords = symbols.get_enabled_keyword_set(
 		opts,
 		filetype,
@@ -452,42 +341,23 @@ function M.render_buffer(main_bufnr, main_winid, current_line_override)
 			table.insert(content_by_line, content or "")
 			table.insert(entry_kinds, entry_kind or "symbol")
 			table.insert(entry_symbols, entry_symbol)
-			table.insert(line_mapping, i) -- AI HINTS: Store source line number
+			table.insert(line_mapping, i)
 		end
 	end
 
 	return rendered, line_mapping, structural_nodes, prefix_settings, content_by_line, entry_kinds, entry_symbols
 end
-
--- AI HINTS: Apply highlighting for relative numbers, arrows, icons, and comments
--- INPUT: minimap_bufnr number: Minimap buffer
--- INPUT: main_bufnr number: Main buffer
--- INPUT: main_winid number: Main window
--- INPUT: current_line_override number|nil: Optional base line override
 function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_winid, current_line_override)
-	-- AI HINTS: This highlight pass covers the "syntax layer" of the minimap:
-	-- AI HINTS: - relative distance number (XmapRelativeNumber)
-	-- AI HINTS: - direction indicator (XmapRelativeUp/Down/Current)
-	-- AI HINTS: - comment markers (MARK/TODO/FIXME/...)
-	-- AI HINTS: - comment lines (doc vs normal)
-	-- AI HINTS: - keyword + entity name highlighting for symbol lines
-	--
-	-- AI HINTS: It intentionally does not touch:
-	-- AI HINTS: - viewport background (ns_viewport)
-	-- AI HINTS: - minimap cursor line background (ns_cursor)
-	-- AI HINTS: - structural scope highlights (ns_structure)
+	-- PURPOSE:
+	-- - Repaint only prefix/comment/entity highlights on existing rendered lines.
+	-- CONSTRAINTS:
+	-- - Use cached `content_by_line` instead of reparsing source text.
 	if not vim.api.nvim_buf_is_valid(minimap_bufnr) or not vim.api.nvim_buf_is_valid(main_bufnr) then
 		return
 	end
 
 	local opts = config.get()
 	local prefix_settings = M.state.relative_prefix_settings or build_relative_prefix_settings(opts)
-
-	-- AI HINTS: Prefix layout is:
-	-- AI HINTS: [number_width chars][number_separator][indicator (padded)][separator]
-	--
-	-- AI HINTS: NOTE: highlight column indices are byte offsets. We compute lengths using `#`
-	-- AI HINTS: on the final prefix fragments to match Neovim's API expectations.
 	local number_width = prefix_settings.number_width or 3
 	local number_sep_len = #(prefix_settings.number_separator or "")
 	local number_end = number_width + number_sep_len
@@ -514,21 +384,11 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 			provider.default_highlight_keywords or provider.default_symbol_keywords or {}
 		) or {}
 	end
-
-	-- AI HINTS: Clear previous highlights
 	highlight.clear(minimap_bufnr, M.ns_syntax)
-
-	-- AI HINTS: Get current line
 	local current_line = current_line_override or navigation.get_main_cursor_line(main_winid)
-
-	-- AI HINTS: Get minimap lines
 	local minimap_lines = vim.api.nvim_buf_get_lines(minimap_bufnr, 0, -1, false)
-
-	-- AI HINTS: Highlight each line
 	for minimap_line_nr = 1, #minimap_lines do
 		local line_text = minimap_lines[minimap_line_nr]
-
-		-- AI HINTS: Get actual source line number from mapping
 		local source_line_nr = M.state.line_mapping[minimap_line_nr]
 		if not source_line_nr then
 			goto continue
@@ -536,11 +396,7 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 		local entry_kind = M.state.entry_kinds and M.state.entry_kinds[minimap_line_nr]
 
 		local delta = source_line_nr - current_line
-
-		-- AI HINTS: Highlight number portion
 		highlight.apply(minimap_bufnr, M.ns_syntax, "XmapRelativeNumber", minimap_line_nr - 1, 0, number_end)
-
-		-- AI HINTS: Highlight direction indicator portion
 		local direction = "current"
 		local hl_group = "XmapRelativeCurrent"
 		if delta < 0 then
@@ -553,8 +409,6 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 
 		local indicator_end = indicator_start + (indicator_field_lens[direction] or 0)
 		highlight.apply(minimap_bufnr, M.ns_syntax, hl_group, minimap_line_nr - 1, indicator_start, indicator_end)
-
-		-- AI HINTS: Check for special comment markers (highlight the entire marker line for visibility)
 		if line_text:match("⚑ MARK:") then
 			local icon_pos = line_text:find("⚑")
 			if icon_pos then
@@ -628,7 +482,6 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 				)
 			end
 		else
-			-- AI HINTS: Rendered comment lines start with a comment icon; highlight accordingly.
 			local comment_icon = COMMENT_ICON
 			local comment_icon_pos = line_text:find(comment_icon, 1, true)
 			if comment_icon_pos then
@@ -683,12 +536,8 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 					goto continue
 				end
 			end
-
-			-- AI HINTS: Try to highlight keywords on ALL lines, not just structural nodes
-			-- AI HINTS: Text format: " 22↓ 󰊕 func init"
-			-- AI HINTS: Skip prefix and icons, then find the first letter
-			local _, text_start = line_text:find("^[^%a]*") -- AI HINTS: Skip everything that's not a letter
-			text_start = text_start and text_start + 1 -- AI HINTS: Position after non-letters
+			local _, text_start = line_text:find("^[^%a]*")
+			text_start = text_start and text_start + 1
 
 			if text_start and text_start <= #line_text then
 				local text_after_numbers = line_text:sub(text_start)
@@ -700,9 +549,7 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 						if next_char ~= "" and next_char:match("[%w_]") then
 							goto continue_keyword
 						end
-
-						-- AI HINTS: Found keyword at start of text
-						local kw_pos_in_line = text_start - 1 + kw_start - 1 -- AI HINTS: Position in full line (0-indexed)
+						local kw_pos_in_line = text_start - 1 + kw_start - 1
 						local kw_end_pos_in_line = text_start - 1 + kw_end
 
 						local keyword_hl = "XmapRelativeKeyword"
@@ -714,8 +561,6 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 								entity_hl = heading_hl
 							end
 						end
-
-						-- AI HINTS: Highlight keyword with colorscheme color
 						highlight.apply(
 							minimap_bufnr,
 							M.ns_syntax,
@@ -724,8 +569,6 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 							kw_pos_in_line,
 							kw_end_pos_in_line
 						)
-
-						-- AI HINTS: Highlight entity name after keyword (starting right after the space)
 						local entity_start = kw_end_pos_in_line
 						if entity_start < #line_text then
 							highlight.apply(
@@ -746,21 +589,9 @@ function M.apply_relative_number_highlighting(minimap_bufnr, main_bufnr, main_wi
 		::continue::
 	end
 end
-
--- AI HINTS: Apply syntax highlighting based on Tree-sitter
--- INPUT: minimap_bufnr number: Minimap buffer
--- INPUT: main_bufnr number: Main buffer
--- INPUT: structural_nodes table|nil: Optional cached nodes
--- INPUT: current_line_override number|nil: Optional base line override
--- INPUT: prefix_settings_override table|nil: Optional cached prefix settings
 function M.apply_syntax_highlighting(minimap_bufnr, main_bufnr, structural_nodes, current_line_override, prefix_settings_override)
-	-- AI HINTS: Structural highlighting uses Tree-sitter nodes from `treesitter.get_structural_nodes`.
-	-- AI HINTS: We only apply these highlights to lines that are actually rendered in the minimap.
-	--
-	-- AI HINTS: Why compute the prefix length per line?
-	-- AI HINTS: Prefix width can vary when users provide multi-byte direction indicators or
-	-- AI HINTS: different separators. Instead of relying on a cached constant, we compute the
-	-- AI HINTS: exact prefix string for the line and highlight from `#prefix` onward.
+	-- PURPOSE:
+	-- - Apply structural highlights on top of rendered entries.
 	if not vim.api.nvim_buf_is_valid(minimap_bufnr) or not vim.api.nvim_buf_is_valid(main_bufnr) then
 		return
 	end
@@ -784,25 +615,15 @@ function M.apply_syntax_highlighting(minimap_bufnr, main_bufnr, structural_nodes
 	local prefix_settings = prefix_settings_override
 		or M.state.relative_prefix_settings
 		or build_relative_prefix_settings(opts)
-
-	-- AI HINTS: Clear previous structural highlights without touching relative/arrow highlights
 	highlight.clear(minimap_bufnr, M.ns_structure)
-
-	-- AI HINTS: Build a reverse lookup: source line -> minimap line
 	local line_lookup = {}
 	for minimap_line, source_line in ipairs(M.state.line_mapping or {}) do
 		line_lookup[source_line] = minimap_line
 	end
-
-	-- AI HINTS: Get structural nodes from Tree-sitter
 	local nodes = structural_nodes or treesitter.get_structural_nodes(main_bufnr, filetype)
-
-	-- AI HINTS: Apply highlights for each structural node (only if rendered in minimap)
 	for _, node in ipairs(nodes) do
 		local hl_group = treesitter.get_highlight_for_type(node.type)
-
-		-- AI HINTS: Minimaps render only key structural lines, so highlight the start line if present
-		local source_line = node.start_line + 1 -- AI HINTS: convert to 1-indexed
+		local source_line = node.start_line + 1
 		local minimap_line = line_lookup[source_line]
 		if minimap_line then
 			if filetype == "markdown" then
@@ -828,8 +649,6 @@ function M.highlight_cursor_line(minimap_bufnr, minimap_line)
 	if not minimap_line or minimap_line < 1 then
 		return
 	end
-
-	-- AI HINTS: Use an extmark with `hl_eol` so the highlight covers the full window width.
 	pcall(vim.api.nvim_buf_set_extmark, minimap_bufnr, M.ns_cursor, minimap_line - 1, 0, {
 		hl_group = "XmapCursor",
 		hl_eol = true,
@@ -837,14 +656,9 @@ function M.highlight_cursor_line(minimap_bufnr, minimap_line)
 		priority = 100,
 	})
 end
-
--- AI HINTS: Update only the relative prefix + highlighting for cursor moves.
 function M.update_relative_only()
-	-- AI HINTS: CursorMoved events happen frequently. A full render re-parses the whole buffer,
-	-- AI HINTS: so for performance we keep a "prefix-only" path:
-	-- AI HINTS: - reuse previously rendered content (icons + text) from `M.state.content_by_line`
-	-- AI HINTS: - re-render only the relative prefix for each minimap line
-	-- AI HINTS: - re-apply highlights that depend on prefix positions
+	-- PURPOSE:
+	-- - Refresh prefixes/highlights without reparsing the full buffer.
 	if not M.state.is_open or not M.state.bufnr or not M.state.main_bufnr then
 		return
 	end
@@ -856,7 +670,6 @@ function M.update_relative_only()
 
 	local main_winid = resolve_main_winid()
 	if not main_winid then
-		-- AI HINTS: Try to recover target tracking on the next event tick.
 		M.follow_current_target()
 		return
 	end
@@ -889,11 +702,8 @@ function M.update_relative_only()
 		vim.api.nvim_buf_set_lines(M.state.bufnr, 0, -1, false, updated)
 		vim.api.nvim_buf_set_option(M.state.bufnr, "modifiable", false)
 	end
-
-	-- AI HINTS: Clear background-style highlights (viewport/cursor) and refresh syntax highlights.
 	highlight.clear(M.state.bufnr, M.ns_viewport)
 	highlight.clear(M.state.bufnr, M.ns_cursor)
-	-- AI HINTS: Structural highlights are re-applied too because they start *after* the prefix.
 	M.apply_syntax_highlighting(M.state.bufnr, M.state.main_bufnr, M.state.structural_nodes, current_line, prefix_settings)
 	M.apply_relative_number_highlighting(M.state.bufnr, M.state.main_bufnr, main_winid, current_line)
 
@@ -910,7 +720,6 @@ function M.update_relative_only()
 end
 
 function M.throttled_relative_update()
-	-- AI HINTS: Debounce prefix-only updates to avoid spamming work during rapid cursor motion.
 	local opts = config.get()
 	local now = vim.loop.now()
 
@@ -926,14 +735,7 @@ function M.throttled_relative_update()
 
 	M.update_relative_only()
 end
-
--- AI HINTS: Update minimap content
 function M.update()
-	-- AI HINTS: Full render path:
-	-- AI HINTS: - re-scan buffer lines
-	-- AI HINTS: - re-run provider parsing and keyword filtering
-	-- AI HINTS: - refresh structural nodes (Tree-sitter) if enabled
-	-- AI HINTS: - update the minimap buffer lines + caches
 	if not M.state.is_open or not M.state.bufnr or not M.state.main_bufnr then
 		return
 	end
@@ -945,17 +747,12 @@ function M.update()
 
 	local main_winid = resolve_main_winid()
 	if not main_winid then
-		-- AI HINTS: Main window may have been replaced; request a follow pass and retry later.
 		M.follow_current_target()
 		return
 	end
-
-	-- AI HINTS: Render buffer content with relative line numbers
 	local current_line = get_relative_base_line(main_winid)
 	local rendered_lines, line_mapping, structural_nodes, prefix_settings, content_by_line, entry_kinds, entry_symbols =
 		M.render_buffer(M.state.main_bufnr, main_winid, current_line)
-
-	-- AI HINTS: Store line mapping for navigation
 	M.state.line_mapping = line_mapping
 	M.state.content_by_line = content_by_line or {}
 	M.state.entry_kinds = entry_kinds or {}
@@ -964,19 +761,13 @@ function M.update()
 	if prefix_settings then
 		M.state.relative_prefix_settings = prefix_settings
 	end
-
-	-- AI HINTS: Update minimap buffer
 	vim.api.nvim_buf_set_option(M.state.bufnr, "modifiable", true)
 	vim.api.nvim_buf_set_lines(M.state.bufnr, 0, -1, false, rendered_lines)
 	vim.api.nvim_buf_set_option(M.state.bufnr, "modifiable", false)
-
-	-- AI HINTS: Apply syntax highlighting for arrows, numbers, icons, and structure
 	highlight.clear(M.state.bufnr, M.ns_viewport)
 	highlight.clear(M.state.bufnr, M.ns_cursor)
 	M.apply_syntax_highlighting(M.state.bufnr, M.state.main_bufnr, structural_nodes, current_line, prefix_settings)
 	M.apply_relative_number_highlighting(M.state.bufnr, M.state.main_bufnr, main_winid, current_line)
-
-	-- AI HINTS: Update minimap cursor to follow main buffer
 	local main_line = navigation.get_main_cursor_line(main_winid)
 	if M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
 		local is_minimap_focused = vim.api.nvim_get_current_win() == M.state.winid
@@ -989,17 +780,10 @@ function M.update()
 
 	M.state.last_update = vim.loop.now()
 end
-
--- AI HINTS: Throttled update function
 function M.throttled_update()
-	-- AI HINTS: Debounce full renders to avoid doing heavy work on every keystroke.
-	-- AI HINTS: The throttle interval is shared with prefix-only updates for consistency.
 	local opts = config.get()
 	local now = vim.loop.now()
-
-	-- AI HINTS: Check if enough time has passed since last update
 	if now - M.state.last_update < opts.render.throttle_ms then
-		-- AI HINTS: Schedule update for later
 		if M.state.update_timer then
 			M.state.update_timer:stop()
 		end
@@ -1013,15 +797,14 @@ function M.throttled_update()
 
 	M.update()
 end
-
--- AI HINTS: Follow the currently active window/buffer when minimap is open.
--- AI HINTS: This keeps the minimap in sync when switching buffers or windows.
 function M._follow_current_target()
-	-- AI HINTS: This function implements "follow active buffer" semantics:
-	-- AI HINTS: 1) If the currently focused window/buffer is a supported target, attach to it.
-	-- AI HINTS: 2) Else, if the previously attached target still exists, try to find a window showing it.
-	-- AI HINTS: 3) Else, scan all windows for the first supported target.
-	-- AI HINTS: 4) If no supported buffers remain, close the minimap.
+	-- PURPOSE:
+	-- - Reattach the minimap to the best supported buffer/window after editor state changes.
+	-- ALGORITHM:
+	-- - Prefer the current non-minimap window if supported.
+	-- - Reuse the existing main buffer when still visible.
+	-- - Fall back to any other supported window.
+	-- - Close the minimap if no supported target remains.
 	if not M.state.is_open then
 		return
 	end
@@ -1046,7 +829,6 @@ function M._follow_current_target()
 	end
 
 	local function attach_target(main_bufnr, main_winid)
-		-- AI HINTS: Switching targets requires updating autocmds (buffer-local) and re-rendering.
 		local buffer_changed = main_bufnr ~= M.state.main_bufnr
 		local win_changed = main_winid ~= M.state.main_winid
 
@@ -1114,8 +896,6 @@ function M._follow_current_target()
 end
 
 function M.follow_current_target()
-	-- AI HINTS: Coalesce multiple follow requests into a single scheduled callback.
-	-- AI HINTS: This avoids "double renders" when multiple autocmds fire in a row.
 	if M.state.follow_scheduled then
 		return
 	end
@@ -1125,60 +905,37 @@ function M.follow_current_target()
 		M._follow_current_target()
 	end)
 end
-
--- AI HINTS: Open minimap for current buffer
 function M.open()
-	-- AI HINTS: Creates the minimap buffer + window and attaches to the currently active buffer.
-	-- AI HINTS: All further following/switching is handled by follow_current_target/autocmds.
-	-- AI HINTS: Check if already open
 	if M.state.is_open and M.state.winid and vim.api.nvim_win_is_valid(M.state.winid) then
 		return
 	end
-
-	-- AI HINTS: Get current buffer and window
 	local main_bufnr = vim.api.nvim_get_current_buf()
 	local main_winid = vim.api.nvim_get_current_win()
-
-	-- AI HINTS: Check if filetype is supported
 	local filetype = vim.api.nvim_buf_get_option(main_bufnr, "filetype")
 	if not config.is_filetype_supported(filetype) then
 		vim.notify("Minimap not supported for filetype: " .. filetype, vim.log.levels.INFO)
 		return
 	end
-
-	-- AI HINTS: Create buffer and window
 	local bufnr = M.create_buffer()
 	local winid = M.create_window(bufnr)
-
-	-- AI HINTS: Store state
 	M.state.bufnr = bufnr
 	M.state.winid = winid
 	M.state.main_bufnr = main_bufnr
 	M.state.main_winid = main_winid
 	M.state.is_open = true
-
-	-- AI HINTS: Set up keymaps for minimap
 	navigation.setup_minimap_keymaps(bufnr, winid, main_bufnr, main_winid)
-
-	-- AI HINTS: Initial render
 	M.update()
-
-	-- AI HINTS: Set up autocommands for updating minimap
 	M.setup_autocommands()
 end
-
--- AI HINTS: Close minimap
 function M.close()
-	-- AI HINTS: Stops timers, removes autocmds, closes the minimap window, deletes the buffer,
-	-- AI HINTS: and resets state so a future open starts clean.
+	-- PURPOSE:
+	-- - Tear down timers, autocmds, scratch state, and the minimap window.
 	if not M.state.is_open then
 		return
 	end
 
 	local minimap_bufnr = M.state.bufnr
 	local minimap_winid = M.state.winid
-
-	-- AI HINTS: Clear timers
 	if M.state.update_timer then
 		M.state.update_timer:stop()
 		M.state.update_timer = nil
@@ -1187,13 +944,7 @@ function M.close()
 		M.state.relative_timer:stop()
 		M.state.relative_timer = nil
 	end
-
-	-- AI HINTS: Clear autocommands
 	pcall(vim.api.nvim_del_augroup_by_name, "XmapUpdate")
-
-	-- AI HINTS: Close window (or repurpose it if it's the last window in the tabpage)
-	-- AI HINTS: When the minimap is the only window left in a tabpage, closing it would close the
-	-- AI HINTS: entire tab/window. Instead, we "repurpose" it by showing some other buffer.
 	if minimap_winid and vim.api.nvim_win_is_valid(minimap_winid) then
 		local tabpage = vim.api.nvim_win_get_tabpage(minimap_winid)
 		local wins = vim.api.nvim_tabpage_list_wins(tabpage)
@@ -1201,6 +952,8 @@ function M.close()
 		if #wins > 1 then
 			pcall(vim.api.nvim_win_close, minimap_winid, true)
 		else
+			-- CONSTRAINTS:
+			-- - Do not close the last window in the tabpage.
 			local replacement_bufnr = nil
 
 			if
@@ -1233,13 +986,9 @@ function M.close()
 			end
 		end
 	end
-
-	-- AI HINTS: Delete buffer
 	if minimap_bufnr and vim.api.nvim_buf_is_valid(minimap_bufnr) then
 		pcall(vim.api.nvim_buf_delete, minimap_bufnr, { force = true })
 	end
-
-	-- AI HINTS: Reset state
 	M.state.bufnr = nil
 	M.state.winid = nil
 	M.state.main_bufnr = nil
@@ -1254,8 +1003,6 @@ function M.close()
 	M.state.navigation_anchor_line = nil
 	M.state.follow_scheduled = false
 end
-
--- AI HINTS: Toggle minimap
 function M.toggle()
 	if M.state.is_open then
 		M.close()
@@ -1263,11 +1010,9 @@ function M.toggle()
 		M.open()
 	end
 end
-
--- AI HINTS: Set up autocommands for minimap updates
 function M.setup_autocommands()
-	-- AI HINTS: Autocmds are buffer-local to the current main buffer and are recreated whenever
-	-- AI HINTS: the minimap attaches to a different buffer.
+	-- PURPOSE:
+	-- - Keep rendering, follow-target, and cursor sync attached to the current main buffer.
 	local augroup = vim.api.nvim_create_augroup("XmapUpdate", { clear = true })
 
 	local function sync_main_window_from_event()
@@ -1281,8 +1026,6 @@ function M.setup_autocommands()
 			M.state.main_winid = current_winid
 		end
 	end
-
-	-- AI HINTS: Update on text changes
 	vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
 		group = augroup,
 		buffer = M.state.main_bufnr,
@@ -1291,15 +1034,11 @@ function M.setup_autocommands()
 			M.throttled_update()
 		end,
 	})
-
-	-- AI HINTS: Update on cursor movement
 	vim.api.nvim_create_autocmd("CursorMoved", {
 		group = augroup,
 		buffer = M.state.main_bufnr,
 		callback = function()
 			sync_main_window_from_event()
-
-			-- AI HINTS: Use the fast prefix-only update if we already have a mapping.
 			if
 				M.state.bufnr
 				and vim.api.nvim_buf_is_valid(M.state.bufnr)
@@ -1312,10 +1051,6 @@ function M.setup_autocommands()
 			M.throttled_update()
 		end,
 	})
-
-	-- AI HINTS: Keep a cursor highlight inside the minimap:
-	-- AI HINTS: - while focused: follows minimap cursor (navigation)
-	-- AI HINTS: - while not focused: follows main cursor mapping
 	vim.api.nvim_create_autocmd({ "BufWinEnter", "WinEnter" }, {
 		group = augroup,
 		buffer = M.state.bufnr,
@@ -1389,8 +1124,6 @@ function M.setup_autocommands()
 			end
 		end,
 	})
-
-	-- AI HINTS: Update on buffer write
 	vim.api.nvim_create_autocmd("BufWritePost", {
 		group = augroup,
 		buffer = M.state.main_bufnr,
@@ -1399,8 +1132,6 @@ function M.setup_autocommands()
 			M.update()
 		end,
 	})
-
-	-- AI HINTS: Close minimap when main buffer is closed, deleted, or unloaded
 	vim.api.nvim_create_autocmd({ "BufWipeout", "BufDelete", "BufUnload" }, {
 		group = augroup,
 		buffer = M.state.main_bufnr,
@@ -1408,8 +1139,6 @@ function M.setup_autocommands()
 			M.follow_current_target()
 		end,
 	})
-
-	-- AI HINTS: Keep minimap target in sync when switching buffers/windows.
 	vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "FileType" }, {
 		group = augroup,
 		callback = function()
@@ -1420,8 +1149,6 @@ function M.setup_autocommands()
 			M.follow_current_target()
 		end,
 	})
-
-	-- AI HINTS: Handle window resize
 	vim.api.nvim_create_autocmd("VimResized", {
 		group = augroup,
 		callback = function()
@@ -1432,9 +1159,6 @@ function M.setup_autocommands()
 		end,
 	})
 end
-
--- AI HINTS: Check if minimap is open
--- OUTPUT: boolean
 function M.is_open()
 	return M.state.is_open
 end

--- a/lua/xmap/navigation.lua
+++ b/lua/xmap/navigation.lua
@@ -1,37 +1,20 @@
--- AI HINTS: lua/xmap/navigation.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Navigation and jumping logic for xmap.nvim
---
--- AI HINTS: This module is responsible for moving between the minimap and the main buffer.
--- AI HINTS: It is intentionally kept separate from rendering so that:
--- AI HINTS: - minimap.lua can focus on "what to show"
--- AI HINTS: - navigation.lua can focus on "how to move/jump"
---
--- AI HINTS: Key ideas:
--- AI HINTS: - The minimap buffer is a derived view: not every source line is necessarily rendered.
--- AI HINTS: - `minimap.state.line_mapping` maps minimap-line -> source-line (both 1-indexed).
--- AI HINTS: - Jump/preview operations always resolve through that mapping when available.
+-- PURPOSE:
+-- - Own jumps and cursor sync between minimap and source window.
+-- CONSTRAINTS:
+-- - Resolve all navigation through `line_mapping` when available.
 
 local config = require("xmap.config")
 
 local M = {}
 
 local function clamp(value, min_value, max_value)
-  -- AI HINTS: Common helper: keep a number within a safe range.
   return math.max(min_value, math.min(value, max_value))
 end
-
--- AI HINTS: Module-local state tracking (used mainly for UX / debugging).
 M.state = {
-  minimap_cursor_line = 1, -- AI HINTS: Current line in minimap (1-indexed)
-  last_jump_line = nil, -- AI HINTS: Last line jumped to
+  minimap_cursor_line = 1,
+  last_jump_line = nil,
 }
-
--- AI HINTS: Get current line in main buffer
--- INPUT: winid number: Window ID of main buffer
--- OUTPUT: number: Current line (1-indexed)
 function M.get_main_cursor_line(winid)
-  -- AI HINTS: Defensive: if a window is invalid (e.g. closed) just return a safe default.
   if not winid or not vim.api.nvim_win_is_valid(winid) then
     return 1
   end
@@ -39,62 +22,28 @@ function M.get_main_cursor_line(winid)
   local cursor = vim.api.nvim_win_get_cursor(winid)
   return cursor[1]
 end
-
--- AI HINTS: Jump from minimap to main buffer
--- INPUT: minimap_bufnr number: Minimap buffer number
--- INPUT: minimap_winid number: Minimap window ID
--- INPUT: main_bufnr number: Main buffer number
--- INPUT: main_winid number: Main window ID
 function M.jump_to_line(minimap_bufnr, minimap_winid, main_bufnr, main_winid)
-  -- AI HINTS: Jump is triggered from inside the minimap (default: <CR>).
   if not vim.api.nvim_win_is_valid(minimap_winid) or not vim.api.nvim_win_is_valid(main_winid) then
     return
   end
-
-  -- AI HINTS: Get current cursor position in minimap
   local cursor = vim.api.nvim_win_get_cursor(minimap_winid)
   local minimap_line = cursor[1]
-
-  -- AI HINTS: Get line mapping from minimap state
   local minimap = require("xmap.minimap")
   local line_mapping = minimap.state.line_mapping
-
-  -- AI HINTS: Map minimap line to actual source line
   local target_line = line_mapping[minimap_line] or minimap_line
-
-  -- AI HINTS: Get total lines in main buffer
   local main_line_count = vim.api.nvim_buf_line_count(main_bufnr)
-
-  -- AI HINTS: Clamp to valid range
   target_line = math.max(1, math.min(target_line, main_line_count))
-
-  -- AI HINTS: Jump to the line in main buffer
   vim.api.nvim_win_set_cursor(main_winid, { target_line, 0 })
-
-  -- AI HINTS: Center the view if configured
   local opts = config.get()
   if opts.navigation.auto_center then
     vim.api.nvim_win_call(main_winid, function()
       vim.cmd("normal! zz")
     end)
   end
-
-  -- AI HINTS: Focus main window
   vim.api.nvim_set_current_win(main_winid)
-
-  -- AI HINTS: Store last jump
   M.state.last_jump_line = target_line
 end
-
--- AI HINTS: Center main editor on the current minimap selection without changing focus.
--- AI HINTS: Intended for "preview navigation" while the minimap is focused.
--- INPUT: minimap_winid number
--- INPUT: main_bufnr number
--- INPUT: main_winid number
--- INPUT: line_mapping table|nil
 function M.center_main_on_minimap_cursor(minimap_winid, main_bufnr, main_winid, line_mapping)
-  -- AI HINTS: This is used by `navigation.follow_cursor`: while the minimap is focused, moving
-  -- AI HINTS: the minimap cursor previews/centers the main buffer at that location.
   if not (vim.api.nvim_win_is_valid(minimap_winid) and vim.api.nvim_win_is_valid(main_winid)) then
     return
   end
@@ -123,11 +72,6 @@ function M.center_main_on_minimap_cursor(minimap_winid, main_bufnr, main_winid, 
     end)
   end
 end
-
--- AI HINTS: Update minimap cursor to follow main buffer
--- INPUT: minimap_winid number: Minimap window ID
--- INPUT: main_line number: Current line in main buffer (1-indexed)
--- INPUT: line_mapping table|nil: Minimap line -> source line mapping (1-indexed source lines)
 function M.update_minimap_cursor(minimap_winid, main_line, line_mapping)
   if not vim.api.nvim_win_is_valid(minimap_winid) then
     return
@@ -136,8 +80,9 @@ function M.update_minimap_cursor(minimap_winid, main_line, line_mapping)
   local minimap_line = main_line
 
   if type(line_mapping) == "table" and #line_mapping > 0 then
-    -- AI HINTS: Pick the nearest rendered minimap line at-or-before the main cursor.
-    -- AI HINTS: We do a binary search because line_mapping is sorted by source line and can be large.
+    -- ALGORITHM:
+    -- - Pick the nearest rendered line at or before `main_line`.
+    -- - Use binary search because `line_mapping` is sorted by source line.
     local lo, hi = 1, #line_mapping
     local best = 1
 
@@ -161,9 +106,6 @@ function M.update_minimap_cursor(minimap_winid, main_line, line_mapping)
   pcall(vim.api.nvim_win_set_cursor, minimap_winid, { minimap_line, 0 })
   M.state.minimap_cursor_line = minimap_line
 end
-
--- AI HINTS: Focus the minimap window
--- INPUT: minimap_winid number: Minimap window ID
 function M.focus_minimap(minimap_winid)
   if not minimap_winid or not vim.api.nvim_win_is_valid(minimap_winid) then
     vim.notify("Minimap window not found", vim.log.levels.WARN)
@@ -172,10 +114,6 @@ function M.focus_minimap(minimap_winid)
 
   vim.api.nvim_set_current_win(minimap_winid)
 end
-
--- AI HINTS: Get visible line range in main window
--- INPUT: winid number: Window ID
--- OUTPUT: table: { start = number, end = number } (1-indexed)
 function M.get_visible_range(winid)
   if not winid or not vim.api.nvim_win_is_valid(winid) then
     return { start = 1, ["end"] = 1 }
@@ -191,20 +129,13 @@ function M.get_visible_range(winid)
     ["end"] = info.botline,
   }
 end
-
--- AI HINTS: Set up keymaps for minimap buffer
--- INPUT: minimap_bufnr number: Minimap buffer number
--- INPUT: minimap_winid number: Minimap window ID
--- INPUT: main_bufnr number: Main buffer number
--- INPUT: main_winid number: Main window ID
 function M.setup_minimap_keymaps(minimap_bufnr, minimap_winid, main_bufnr, main_winid)
   local opts = config.get()
-
-  -- AI HINTS: Jump to line mapping
   if opts.keymaps.jump then
     vim.keymap.set("n", opts.keymaps.jump, function()
-      -- AI HINTS: The minimap can "follow" different main buffers over time (buffer switching).
-      -- AI HINTS: Always resolve the *current* target buffer/window from minimap state.
+      -- CONSTRAINTS:
+      -- - Resolve the current target from minimap state.
+      -- - Do not trust the window captured when keymaps were installed.
       local minimap = require("xmap.minimap")
       local current_main_bufnr = minimap.state.main_bufnr
       local current_main_winid = minimap.state.main_winid
@@ -222,7 +153,6 @@ function M.setup_minimap_keymaps(minimap_bufnr, minimap_winid, main_bufnr, main_
       end
 
       if not current_main_winid then
-        -- AI HINTS: Fall back to "any window currently showing the target buffer".
         for _, winid in ipairs(vim.api.nvim_list_wins()) do
           if vim.api.nvim_win_get_buf(winid) == current_main_bufnr then
             current_main_winid = winid
@@ -238,8 +168,6 @@ function M.setup_minimap_keymaps(minimap_bufnr, minimap_winid, main_bufnr, main_
       M.jump_to_line(minimap_bufnr, minimap_winid, current_main_bufnr, current_main_winid)
     end, { buffer = minimap_bufnr, silent = true, desc = "Jump to line" })
   end
-
-  -- AI HINTS: Close minimap mapping
   if opts.keymaps.close then
     vim.keymap.set("n", opts.keymaps.close, function()
       require("xmap").close()

--- a/lua/xmap/symbols.lua
+++ b/lua/xmap/symbols.lua
@@ -1,27 +1,7 @@
--- AI HINTS: lua/xmap/symbols.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Keyword configuration helpers for xmap.nvim
---
--- AI HINTS: This module centralizes "what keywords should be visible/highlighted" logic so the core
--- AI HINTS: rendering code doesn't need to know about configuration shapes, aliases, or precedence.
---
--- AI HINTS: Config shape (keyed by filetype):
--- AI HINTS: symbols = {
--- AI HINTS: swift = {
--- AI HINTS: -- `keywords` is an explicit allowlist. When non-empty, ONLY these will be shown.
--- AI HINTS: keywords = { "func", "struct", "enum" },
---
--- AI HINTS: -- `exclude` removes items from the defaults (or from the allowlist above).
--- AI HINTS: exclude = { "let", "var" },
---
--- AI HINTS: -- `highlight_keywords` controls which keywords are highlighted at the start of
--- AI HINTS: -- the rendered line text. When empty, we default to the visible keyword list.
--- AI HINTS: highlight_keywords = { "func", "struct", "enum" },
--- AI HINTS: },
--- AI HINTS: }
---
--- AI HINTS: Backwards-compatible aliases:
--- AI HINTS: - `visible_keywords` and `include` are treated like `keywords`.
+-- PURPOSE:
+-- - Resolve visible and highlighted keywords from per-language config.
+-- CONSTRAINTS:
+-- - Preserve backwards-compatible aliases for older config keys.
 
 local M = {}
 
@@ -40,7 +20,6 @@ local function list_to_set(list)
 end
 
 local function get_lang_opts(opts, filetype)
-  -- AI HINTS: Defensive: keep callers simple by returning `{}` for any invalid input.
   if type(opts) ~= "table" or type(filetype) ~= "string" or filetype == "" then
     return {}
   end
@@ -55,9 +34,8 @@ local function get_lang_opts(opts, filetype)
 end
 
 local function get_base_keywords_list(lang_opts, default_keywords)
-  -- AI HINTS: Precedence:
-  -- AI HINTS: 1) explicit allowlist (`keywords` / aliases)
-  -- AI HINTS: 2) provider defaults
+  -- DO:
+  -- - Prefer explicit allowlists before provider defaults.
   if type(lang_opts.keywords) == "table" and not is_empty(lang_opts.keywords) then
     return lang_opts.keywords
   end
@@ -70,19 +48,14 @@ local function get_base_keywords_list(lang_opts, default_keywords)
 
   return default_keywords or {}
 end
-
--- AI HINTS: -Get enabled (visible) keyword set for a filetype.
--- AI HINTS: -@param opts table
--- AI HINTS: -@param filetype string
--- AI HINTS: -@param default_keywords string[]
--- AI HINTS: -@return table<string, boolean>
 function M.get_enabled_keyword_set(opts, filetype, default_keywords)
   local lang_opts = get_lang_opts(opts, filetype)
   local base = get_base_keywords_list(lang_opts, default_keywords)
 
   local enabled = list_to_set(base)
   if type(lang_opts.exclude) == "table" and not is_empty(lang_opts.exclude) then
-    -- AI HINTS: `exclude` is applied last so it works with both defaults and explicit allowlists.
+    -- CONSTRAINTS:
+    -- - Apply `exclude` after the base list so it works for both defaults and allowlists.
     local exclude_set = list_to_set(lang_opts.exclude)
     for keyword in pairs(exclude_set) do
       enabled[keyword] = nil
@@ -91,19 +64,13 @@ function M.get_enabled_keyword_set(opts, filetype, default_keywords)
 
   return enabled
 end
-
--- AI HINTS: -Get keywords to use for line-start keyword highlighting.
--- AI HINTS: -@param opts table
--- AI HINTS: -@param filetype string
--- AI HINTS: -@param default_keywords string[]
--- AI HINTS: -@return string[]
 function M.get_highlight_keywords(opts, filetype, default_keywords)
   local lang_opts = get_lang_opts(opts, filetype)
   if type(lang_opts.highlight_keywords) == "table" and not is_empty(lang_opts.highlight_keywords) then
     return lang_opts.highlight_keywords
   end
-
-  -- AI HINTS: If the user provided an explicit visible keyword allowlist, default highlighting to that list.
+  -- DO:
+  -- - Fall back to the visible keyword base when highlight-specific config is absent.
   local base = get_base_keywords_list(lang_opts, default_keywords)
   return base or {}
 end

--- a/lua/xmap/treesitter.lua
+++ b/lua/xmap/treesitter.lua
@@ -1,18 +1,9 @@
--- AI HINTS: lua/xmap/treesitter.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Tree-sitter integration for xmap.nvim
---
--- AI HINTS: This module is intentionally small and generic:
--- AI HINTS: - It hides the optional dependency on `nvim-treesitter`.
--- AI HINTS: - It compiles and caches Tree-sitter queries per filetype.
--- AI HINTS: - It exposes helpers to map captures to icons/highlight groups.
---
--- AI HINTS: Language-specific query strings do NOT live here. They come from provider modules
--- AI HINTS: (`lua/xmap/lang/<filetype>.lua`) via `provider.get_query()` / `provider.get_queries()`.
+-- PURPOSE:
+-- - Hide optional Tree-sitter integration behind a small cached API.
+-- CONSTRAINTS:
+-- - Query strings come from language providers, not this module.
 
 local M = {}
-
--- AI HINTS: Check if nvim-treesitter is available
 M.available = false
 
 local lang = require("xmap.lang")
@@ -25,8 +16,6 @@ local function is_non_empty_string(value)
 end
 
 local function resolve_treesitter_language(filetype)
-  -- AI HINTS: Many Neovim filetypes map to a different Tree-sitter language name
-  -- AI HINTS: (e.g. `typescriptreact` -> `tsx`). Resolve this mapping when possible.
   if type(filetype) ~= "string" or filetype == "" then
     return filetype
   end
@@ -46,11 +35,8 @@ local function resolve_treesitter_language(filetype)
 end
 
 local function get_query_candidates(filetype)
-  -- AI HINTS: Providers may expose either:
-  -- AI HINTS: - `get_queries()` -> { "query v3", "query v2", ... } (preferred)
-  -- AI HINTS: - `get_query()` -> "query v1"
-  --
-  -- AI HINTS: We try candidates in order and cache the first one that parses successfully.
+  -- PURPOSE:
+  -- - Accept provider query fallbacks without hard-coding provider shapes downstream.
   local provider = lang.get(filetype)
   if not provider then
     return {}
@@ -74,7 +60,8 @@ local function get_query_candidates(filetype)
 end
 
 local function get_compiled_query(filetype)
-  -- AI HINTS: Cache "misses" as `false` so we don't keep trying to parse broken queries.
+  -- CONSTRAINTS:
+  -- - Cache failed lookups as `false` to avoid repeated parse work and warnings.
   if M._compiled_queries[filetype] ~= nil then
     return M._compiled_queries[filetype] or nil
   end
@@ -99,10 +86,7 @@ local function get_compiled_query(filetype)
   M._compiled_queries[filetype] = false
   return nil, last_error
 end
-
--- AI HINTS: Initialize Tree-sitter integration
 function M.setup()
-  -- AI HINTS: Check if nvim-treesitter is installed
   local ok, _ = pcall(require, "nvim-treesitter")
   M.available = ok
 
@@ -115,10 +99,6 @@ function M.setup()
 
   return M.available
 end
-
--- AI HINTS: Get parser for buffer
--- INPUT: bufnr number: Buffer number
--- OUTPUT: parser|nil: Tree-sitter parser or nil if not available
 function M.get_parser(bufnr)
   if not M.available then
     return nil
@@ -131,10 +111,6 @@ function M.get_parser(bufnr)
 
   return parser
 end
-
--- AI HINTS: Get syntax tree for buffer
--- INPUT: bufnr number: Buffer number
--- OUTPUT: tree|nil: Syntax tree or nil if not available
 function M.get_tree(bufnr)
   local parser = M.get_parser(bufnr)
   if not parser then
@@ -144,11 +120,6 @@ function M.get_tree(bufnr)
   local trees = parser:parse()
   return trees and trees[1] or nil
 end
-
--- AI HINTS: Extract structural nodes (functions, classes, etc.) from buffer
--- INPUT: bufnr number: Buffer number
--- INPUT: filetype string: Filetype
--- OUTPUT: table: List of nodes with their positions and types
 function M.get_structural_nodes(bufnr, filetype)
   if not M.available then
     return {}
@@ -166,7 +137,8 @@ function M.get_structural_nodes(bufnr, filetype)
 
   local query, last_error = get_compiled_query(filetype)
   if not query then
-    -- AI HINTS: We warn only once per filetype to avoid spamming on cursor moves.
+    -- DO:
+    -- - Warn once per filetype.
     if not M._query_error_shown[filetype] then
       vim.notify(string.format("xmap.nvim: Failed to parse Tree-sitter query for %s", filetype), vim.log.levels.WARN)
       M._query_error_shown[filetype] = true
@@ -176,13 +148,9 @@ function M.get_structural_nodes(bufnr, filetype)
 
   local nodes = {}
   local root = tree:root()
-
-  -- AI HINTS: Execute query and collect nodes
   for id, node in query:iter_captures(root, bufnr, 0, -1) do
     local capture_name = query.captures[id]
     local start_row, start_col, end_row, end_col = node:range()
-
-    -- AI HINTS: We store both the capture name and the range so callers can highlight and map to lines.
     table.insert(nodes, {
       type = capture_name,
       start_line = start_row,
@@ -192,29 +160,21 @@ function M.get_structural_nodes(bufnr, filetype)
       node = node,
     })
   end
-
-  -- AI HINTS: Sort by start line
   table.sort(nodes, function(a, b)
     return a.start_line < b.start_line
   end)
 
   return nodes
 end
-
--- AI HINTS: Get the current scope/function at a given line
--- INPUT: bufnr number: Buffer number
--- INPUT: filetype string: Filetype
--- INPUT: line number: Line number (0-indexed)
--- OUTPUT: table|nil: Node containing the line, or nil
 function M.get_scope_at_line(bufnr, filetype, line)
   local nodes = M.get_structural_nodes(bufnr, filetype)
-
-  -- AI HINTS: Find the smallest scope containing this line
   local current_scope = nil
   local smallest_range = math.huge
 
   for _, node in ipairs(nodes) do
     if node.start_line <= line and line <= node.end_line then
+      -- ALGORITHM:
+      -- - Prefer the smallest enclosing node as the active scope.
       local range = node.end_line - node.start_line
       if range < smallest_range then
         smallest_range = range
@@ -225,13 +185,7 @@ function M.get_scope_at_line(bufnr, filetype, line)
 
   return current_scope
 end
-
--- AI HINTS: Get icon for node type
--- INPUT: node_type string: Type of node (from capture)
--- OUTPUT: string: Nerd Font icon
 function M.get_icon_for_type(node_type)
-  -- AI HINTS: Icons are intentionally limited to a small stable set so providers can map their
-  -- AI HINTS: parsed symbol kinds to these without leaking language specifics into core logic.
   local map = {
     ["class"] = "󰠱",
     ["function"] = "󰊕",
@@ -242,13 +196,7 @@ function M.get_icon_for_type(node_type)
 
   return map[node_type] or ""
 end
-
--- AI HINTS: Get highlight group for node type
--- INPUT: node_type string: Type of node (from capture)
--- OUTPUT: string: Highlight group name
 function M.get_highlight_for_type(node_type)
-  -- AI HINTS: Keep capture names generic ("class", "function", ...) so highlight groups are
-  -- AI HINTS: consistent across languages.
   local map = {
     ["class"] = "XmapClass",
     ["function"] = "XmapFunction",
@@ -259,10 +207,6 @@ function M.get_highlight_for_type(node_type)
 
   return map[node_type] or "XmapText"
 end
-
--- AI HINTS: Check if Tree-sitter parser is available for filetype
--- INPUT: filetype string: Filetype to check
--- OUTPUT: boolean: True if parser is available
 function M.has_parser(filetype)
   if not M.available then
     return false

--- a/plugin/xmap.lua
+++ b/plugin/xmap.lua
@@ -1,19 +1,10 @@
--- AI HINTS: plugin/xmap.lua
--- AI HINTS: Copyright (c) Ivan Tokar. MIT License.
--- AI HINTS: Plugin loader for xmap.nvim
---
--- AI HINTS: Neovim loads files in `plugin/` automatically on startup.
--- AI HINTS: This file is responsible only for defining user-facing commands.
--- AI HINTS: The actual implementation lives in `lua/xmap/`.
+-- PURPOSE:
+-- - Register user commands once per Neovim session.
 
--- AI HINTS: Prevent loading twice
 if vim.g.loaded_xmap then
   return
 end
 vim.g.loaded_xmap = true
-
--- AI HINTS: Define user commands
--- AI HINTS: Commands call into the public API (`lua/xmap/init.lua`).
 vim.api.nvim_create_user_command("XmapToggle", function()
   require("xmap").toggle()
 end, { desc = "Toggle Xmap minimap" })

--- a/reload.lua
+++ b/reload.lua
@@ -1,9 +1,10 @@
--- AI HINTS: Reload helper for xmap.nvim development
--- AI HINTS: Usage: :luafile reload.lua
+
+-- PURPOSE:
+-- - Hot-reload xmap during interactive development.
+-- CONSTRAINTS:
+-- - Reset loaded modules before calling `setup()` again.
 
 print("Reloading xmap.nvim...")
-
--- AI HINTS: Close existing minimap
 local ok = pcall(function()
   require("xmap").close()
 end)
@@ -11,8 +12,6 @@ end)
 if ok then
   print("  ✓ Closed existing minimap")
 end
-
--- AI HINTS: Unload all xmap modules
 local count = 0
 for k, _ in pairs(package.loaded) do
   if k:match("^xmap") then
@@ -21,11 +20,9 @@ for k, _ in pairs(package.loaded) do
   end
 end
 print("  ✓ Unloaded " .. count .. " modules")
-
--- AI HINTS: Reload xmap
 local success, err = pcall(function()
   require("xmap").setup({
-    width = 40, -- AI HINTS: Wider to fit relative numbers + icons + text
+    width = 40,
     side = "right",
     treesitter = {
       enable = true,

--- a/scripts/qa_follow_active_buffer.lua
+++ b/scripts/qa_follow_active_buffer.lua
@@ -1,5 +1,6 @@
--- AI HINTS: scripts/qa_follow_active_buffer.lua
--- AI HINTS: Headless regression check: minimap should follow the active buffer/window.
+
+-- PURPOSE:
+-- - Guard the follow-current-buffer workflow against regressions.
 
 local function assert_eq(actual, expected, message)
   if actual ~= expected then

--- a/scripts/qa_smoke_languages.lua
+++ b/scripts/qa_smoke_languages.lua
@@ -1,5 +1,6 @@
--- AI HINTS: scripts/qa_smoke_languages.lua
--- AI HINTS: Headless smoke check: ensure xmap opens/closes across bundled filetypes.
+
+-- PURPOSE:
+-- - Verify that bundled providers open and close the minimap cleanly.
 
 local function assert_true(value, message)
   if not value then
@@ -15,10 +16,8 @@ local cases = {
 	{ path = "test.swift", filetype = "swift" },
 	{ path = "test.ts", filetype = "typescript" },
 	{ path = "test.tsx", filetype = "typescriptreact" },
-	-- AI HINTS: C/C++ provider smoke tests.
 	{ path = "test.c", filetype = "c" },
 	{ path = "test.cpp", filetype = "cpp" },
-	-- AI HINTS: Header aliases: `h` -> C provider, `hpp` -> C++ provider.
 	{ path = "test.c", filetype = "h" },
 	{ path = "test.cpp", filetype = "hpp" },
 }

--- a/test_config.lua
+++ b/test_config.lua
@@ -1,17 +1,7 @@
--- AI HINTS: Test configuration for xmap.nvim
--- AI HINTS: Usage: nvim -u test_config.lua test.swift
--- AI HINTS: nvim -u test_config.lua test.ts
--- AI HINTS: nvim -u test_config.lua test.tsx
--- AI HINTS: nvim -u test_config.lua test.c
--- AI HINTS: nvim -u test_config.lua test.cpp
--- AI HINTS: Header alias coverage can be exercised by setting filetype manually:
--- AI HINTS: :set ft=h
--- AI HINTS: :set ft=hpp
+-- PURPOSE:
+-- - Load xmap from the current checkout with stable local test defaults.
 
--- AI HINTS: Add current directory to runtime path
 vim.opt.rtp:prepend(".")
-
--- AI HINTS: Load xmap
 require("xmap").setup({
   width = 25,
   side = "right",
@@ -27,8 +17,6 @@ require("xmap").setup({
     auto_center = true,
   },
 })
-
--- AI HINTS: Print success message
 print("✓ xmap.nvim loaded successfully!")
 print("Commands: :XmapToggle, :XmapOpen, :XmapClose")
 print("Keymaps: <leader>mm (toggle), <leader>mf (focus)")


### PR DESCRIPTION
Summary
- apply the updated familiar comment contract across the xmap codebase
- remove low-signal narration and keep only concise contract comments in non-obvious areas
- preserve runtime behavior and fixture semantics

Validation
- nvim --headless -u test_config.lua -c 'luafile scripts/qa_smoke_languages.lua' +qa